### PR TITLE
Disable login button and show spinner during process

### DIFF
--- a/addon/components/acmidm-login.js
+++ b/addon/components/acmidm-login.js
@@ -9,6 +9,7 @@ export default Component.extend({
   actions: {
     login() {
       this.set('errorMessage', '');
+      this.set('isAuthenticating', true);
       this.session.authenticate('authenticator:torii', 'acmidm-oauth2').catch((reason) => {
         warn(reason.error || reason, { id: 'authentication.failure' });
 
@@ -16,6 +17,9 @@ export default Component.extend({
           this.set('errorMessage', 'U heeft geen toegang tot deze applicatie.');
         else
           this.set('errorMessage', 'Fout bij het aanmelden. Gelieve opnieuw te proberen.');
+      })
+      .finally(() => {
+        this.set('isAuthenticating', false);
       });
     }
   }

--- a/addon/templates/components/acmidm-login.hbs
+++ b/addon/templates/components/acmidm-login.hbs
@@ -1,4 +1,7 @@
-{{#wu-button class="button--large u-spacer" onClick=(action "login")}}Meld u aan{{/wu-button}}
+{{#wu-button class="button--large u-spacer" disabled=isAuthenticating onClick=(action "login")}}Meld u aan{{/wu-button}}
+{{#if isAuthenticating}}
+  {{wu-loader}}
+{{/if}}
 {{#if errorMessage}}
   {{wu-alert title=errorMessage isError=true}}
 {{/if}}


### PR DESCRIPTION
-Prevent clicking the login multiple times during the authentication process
-Show a spinner during the process to give feedback to the users