### PR TITLE
Create Login and Switch provider components

### DIFF
--- a/addon/components/acmidm-login.hbs
+++ b/addon/components/acmidm-login.hbs
@@ -1,6 +1,12 @@
-<AuButton @loading={{this.isAuthenticating}} @disabled={{this.isAuthenticating}} {{on "click" this.login}}>
-  Meld u aan
-</AuButton>
-{{#if this.errorMessage}}
-  <AuAlert @alertIcon="alert-triangle" @alertTitle={{this.errorMessage}} />
-{{/if}}
+<Acmidm::Login as |acmidm|>
+  <AuButton
+    @loading={{acmidm.isAuthenticating}}
+    @disabled={{acmidm.isAuthenticating}}
+    {{on "click" acmidm.login}}
+  >
+    Meld u aan
+  </AuButton>
+  {{#if acmidm.errorMessage}}
+    <AuAlert @alertIcon="alert-triangle" @alertTitle={{acmidm.errorMessage}} />
+  {{/if}}
+</Acmidm::Login>

--- a/addon/components/acmidm-login.js
+++ b/addon/components/acmidm-login.js
@@ -1,31 +1,4 @@
-import { warn } from '@ember/debug';
-import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
+import templateOnly from '@ember/component/template-only';
 
-export default class AcmIdmLoginComponent extends Component {
-  @tracked errorMessage = '';
-  @tracked isAuthenticating = false;
-  @service session;
-
-  @action
-  login() {
-    this.errorMessage = '';
-    this.isAuthenticating = true;
-    this.session
-      .authenticate('authenticator:torii', 'acmidm-oauth2')
-      .catch((reason) => {
-        warn(reason.error || reason, { id: 'authentication.failure' });
-
-        if (reason.status == 403)
-          this.errorMessage = 'U heeft geen toegang tot deze applicatie.';
-        else
-          this.errorMessage =
-            'Fout bij het aanmelden. Gelieve opnieuw te proberen.';
-      })
-      .finally(() => {
-        this.isAuthenticating = false;
-      });
-  }
-}
+const AcmidmLoginComponent = templateOnly();
+export default AcmidmLoginComponent;

--- a/addon/components/acmidm-switch.hbs
+++ b/addon/components/acmidm-switch.hbs
@@ -1,7 +1,9 @@
-<button ...attributes disabled={{this.disabled}} type="button" {{on "click" this.switch}}>
-  {{#if (has-block)}}
-  {{yield}}
-{{else}}
-  Wissel van bestuurseenheid
-{{/if}}
-</button>
+<Acmidm::Switch as |acmidm|>
+  <button ...attributes disabled={{acmidm.isSwitching}} type="button" {{on "click" acmidm.switch}}>
+    {{#if (has-block)}}
+      {{yield}}
+    {{else}}
+      Wissel van bestuurseenheid
+    {{/if}}
+  </button>
+</Acmidm::Switch>

--- a/addon/components/acmidm-switch.js
+++ b/addon/components/acmidm-switch.js
@@ -1,40 +1,4 @@
-import Component from '@glimmer/component';
-import { getOwner } from '@ember/application';
-import fetch from 'fetch';
-import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
-export default class AcmIdmSwitchComponent extends Component {
-  @tracked disabled = false;
-  constructor() {
-    super(...arguments);
-    const config =
-      getOwner(this).resolveRegistration('config:environment')?.torii;
-    const providerConfig = config?.providers
-      ? config.providers['acmidm-oauth2']
-      : null;
-    if (!providerConfig) {
-      throw 'could not find acmidm-oauth2 configuration, make sure it is set in your application environment';
-    }
-    this.logoutUrl = providerConfig.logoutUrl;
-    this.clientId = providerConfig.clientId;
-    this.returnUrl = providerConfig.returnUrl;
-  }
+import templateOnly from '@ember/component/template-only';
 
-  @action
-  async switch() {
-    this.disabled = true;
-    try {
-      await fetch('/sessions/current', {
-        method: 'DELETE',
-        credentials: 'same-origin',
-      });
-      window.location.replace(
-        `${this.logoutUrl}?switch=true&client_id=${
-          this.clientId
-        }&post_logout_redirect_uri=${encodeURIComponent(this.returnUrl)}`
-      );
-    } catch (e) {
-      this.disabled = false;
-    }
-  }
-}
+const AcmidmSwitchComponent = templateOnly();
+export default AcmidmSwitchComponent;

--- a/addon/components/acmidm/login.hbs
+++ b/addon/components/acmidm/login.hbs
@@ -1,0 +1,5 @@
+{{yield (hash
+  login=this.login
+  isAuthenticating=this.isAuthenticating
+  errorMessage=this.errorMessage
+)}}

--- a/addon/components/acmidm/login.js
+++ b/addon/components/acmidm/login.js
@@ -1,0 +1,33 @@
+import { warn } from '@ember/debug';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class AcmIdmLoginComponent extends Component {
+  @service session;
+
+  @tracked errorMessage = '';
+  @tracked isAuthenticating = false;
+
+  @action
+  async login() {
+    this.errorMessage = '';
+    this.isAuthenticating = true;
+
+    try {
+      await this.session.authenticate('authenticator:torii', 'acmidm-oauth2');
+    } catch (reason) {
+      warn(reason.error || reason, { id: 'authentication.failure' });
+
+      if (reason.status == 403) {
+        this.errorMessage = 'U heeft geen toegang tot deze applicatie.';
+      } else {
+        this.errorMessage =
+          'Fout bij het aanmelden. Gelieve opnieuw te proberen.';
+      }
+    } finally {
+      this.isAuthenticating = false;
+    }
+  }
+}

--- a/addon/components/acmidm/switch.hbs
+++ b/addon/components/acmidm/switch.hbs
@@ -1,0 +1,4 @@
+{{yield (hash
+  switch=this.switch
+  isSwitching=this.isSwitching
+)}}

--- a/addon/components/acmidm/switch.js
+++ b/addon/components/acmidm/switch.js
@@ -1,0 +1,48 @@
+import { getOwner } from '@ember/application';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import fetch from 'fetch';
+
+export default class AcmIdmSwitchComponent extends Component {
+  @tracked isSwitching = false;
+
+  constructor() {
+    super(...arguments);
+
+    const config =
+      getOwner(this).resolveRegistration('config:environment')?.torii;
+
+    const providerConfig = config?.providers
+      ? config.providers['acmidm-oauth2']
+      : null;
+
+    if (!providerConfig) {
+      throw 'could not find acmidm-oauth2 configuration, make sure it is set in your application environment';
+    }
+
+    this.logoutUrl = providerConfig.logoutUrl;
+    this.clientId = providerConfig.clientId;
+    this.returnUrl = providerConfig.returnUrl;
+  }
+
+  @action
+  async switch() {
+    this.isSwitching = true;
+
+    try {
+      await fetch('/sessions/current', {
+        method: 'DELETE',
+        credentials: 'same-origin',
+      });
+
+      window.location.replace(
+        `${this.logoutUrl}?switch=true&client_id=${
+          this.clientId
+        }&post_logout_redirect_uri=${encodeURIComponent(this.returnUrl)}`
+      );
+    } catch (e) {
+      this.isSwitching = false;
+    }
+  }
+}

--- a/app/components/acmidm/login.js
+++ b/app/components/acmidm/login.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-acmidm-login/components/acmidm/login';

--- a/app/components/acmidm/switch.js
+++ b/app/components/acmidm/switch.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-acmidm-login/components/acmidm/switch';

--- a/tests/integration/components/acmidm/login-test.js
+++ b/tests/integration/components/acmidm/login-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | acmidm/login', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Acmidm::Login />`);
+
+    assert.dom(this.element).hasText('');
+
+    // Template block usage:
+    await render(hbs`
+      <Acmidm::Login>
+        template block text
+      </Acmidm::Login>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+});

--- a/tests/integration/components/acmidm/switch-test.js
+++ b/tests/integration/components/acmidm/switch-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | acmidm/switch', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<Acmidm::Switch />`);
+
+    assert.dom(this.element).hasText('');
+
+    // Template block usage:
+    await render(hbs`
+      <Acmidm::Switch>
+        template block text
+      </Acmidm::Switch>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+});


### PR DESCRIPTION
As discussed here: https://github.com/lblod/ember-acmidm-login/pull/4#discussion_r685131726

These components are styling independent so apps can use them if the default button components don't cover the needed use cases. I also used the provider component to "reimplement" the button components already.

I didn't create a component for the logout button since I think it should be removed :smile:.

I still think that keeping the addon styling independant is the best way forward but shipping it this way will make that transition easier since it's not a breaking change. The buttons can also be deprecated first to make it clear that change is coming.