### PR TITLE
read apiKey into clientId as we did before 1.2.0

### DIFF
--- a/addon/components/acmidm/switch.js
+++ b/addon/components/acmidm/switch.js
@@ -22,7 +22,7 @@ export default class AcmIdmSwitchComponent extends Component {
     }
 
     this.logoutUrl = providerConfig.logoutUrl;
-    this.clientId = providerConfig.clientId;
+    this.clientId = providerConfig.apiKey;
     this.returnUrl = providerConfig.returnUrl;
   }
 


### PR DESCRIPTION
during the conversion to octane we missed that the key in the config and the
parameter name in the component were not inline. For backwards compatibility
we're reinstating that.