### PR TITLE
release-it setup updates

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -6,7 +6,8 @@
     ]
   },
   "github": {
-    "release": true
+    "release": true,
+    "tokenRef": "GITHUB_AUTH"
   },
   "plugins": {
     "release-it-lerna-changelog": {

--- a/README.md
+++ b/README.md
@@ -98,6 +98,25 @@ See the [Contributing](CONTRIBUTING.md) guide for details.
 
 NOTE: There's currently an issue when using this addon with npm link when using in a host app with ember-source < 3.27, see [this comment](https://github.com/lblod/ember-acmidm-login/pull/4#issuecomment-907618192) for more information.
 
+
+Releasing a new version
+------------------------------------------------------------------------------
+We use [`release-it`](https://github.com/release-it/release-it) to handle our release flow and [`lerna-changelog`](https://github.com/lerna/lerna-changelog) to generate the changelog for that release.
+
+### Prerequisites
+- Both `release-it` and `lerna-changelog` require a Github [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) to work properly.
+- All PRs that need to show up in the changelog need a descriptive title and [correct label](https://github.com/lerna/lerna-changelog).
+
+### Previewing the changelog (optional)
+If you want to preview the changelog that will be generated before starting the release flow you can run the following command:
+
+`GITHUB_AUTH=your-access-token npx lerna-changelog`
+
+### Creating a new release
+Simply run `GITHUB_AUTH=your-access-token npm run release` and follow the prompts.
+
+After the new tag is created and pushed Drone will take care of publishing the package to npm.
+
 License
 ------------------------------------------------------------------------------
 

--- a/package.json
+++ b/package.json
@@ -20,18 +20,19 @@
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
+    "release": "release-it",
     "start": "ember serve",
     "test": "npm-run-all lint test:*",
     "test:ember": "ember test",
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^7.26.6",
-    "ember-cli-htmlbars": "^5.7.1",
-    "ember-simple-auth": "^3.0.0 || ^4.2.1",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
+    "ember-cli-babel": "^7.26.6",
+    "ember-cli-htmlbars": "^5.7.1",
     "ember-fetch": "^8.1.0",
+    "ember-simple-auth": "^3.0.0 || ^4.2.1",
     "torii": "^0.10.1"
   },
   "peerDependencies": {
@@ -73,7 +74,9 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.3.0",
     "qunit": "^2.15.0",
-    "qunit-dom": "^1.6.0"
+    "qunit-dom": "^1.6.0",
+    "release-it": "^14.12.5",
+    "release-it-lerna-changelog": "^4.0.1"
   },
   "engines": {
     "node": "10.* || >= 12"


### PR DESCRIPTION
- Use GITHUB_AUTH as the environment variable. This variable is also used by lerna-changelog, so we no longer need to provide the key 2 times.
- add a 'release' npm script