### PR TITLE
Also allow ember-simple-auth v5 and v6

### DIFF
--- a/ember-acmidm-login/package.json
+++ b/ember-acmidm-login/package.json
@@ -28,7 +28,7 @@
     "@embroider/addon-shim": "^1.0.0"
   },
   "peerDependencies": {
-    "ember-simple-auth": "4.x"
+    "ember-simple-auth": "4.x || 5.x || 6.x"
   },
   "devDependencies": {
     "@babel/core": "^7.17.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,6 @@
         "ember-acmidm-login",
         "test-app"
       ],
-      "dependencies": {
-        "ember-simple-auth": "^4.2.2"
-      },
       "devDependencies": {
         "@release-it-plugins/workspaces": "^3.2.0",
         "concurrently": "^7.2.1",
@@ -49,7 +46,7 @@
         "rollup-plugin-copy": "^3.4.0"
       },
       "peerDependencies": {
-        "ember-simple-auth": "4.x"
+        "ember-simple-auth": "4.x || 5.x || 6.x"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1913,7 +1910,7 @@
     },
     "node_modules/@ember/edition-utils": {
       "version": "1.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@ember/optional-features": {
@@ -2012,7 +2009,7 @@
     },
     "node_modules/@ember/test-helpers": {
       "version": "2.8.1",
-      "dev": true,
+      "devOptional": true,
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@ember/test-waiters": "^3.0.0",
@@ -2033,7 +2030,7 @@
     },
     "node_modules/@ember/test-helpers/node_modules/broccoli-plugin": {
       "version": "4.0.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "broccoli-node-api": "^1.7.0",
@@ -2050,7 +2047,7 @@
     },
     "node_modules/@ember/test-helpers/node_modules/ember-cli-htmlbars": {
       "version": "5.7.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@ember/edition-utils": "^1.2.0",
@@ -2076,7 +2073,7 @@
     },
     "node_modules/@ember/test-helpers/node_modules/promise-map-series": {
       "version": "0.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "10.* || >= 12.*"
@@ -2084,7 +2081,7 @@
     },
     "node_modules/@ember/test-helpers/node_modules/rimraf": {
       "version": "3.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -2098,7 +2095,6 @@
     },
     "node_modules/@ember/test-waiters": {
       "version": "3.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "calculate-cache-key-for-tree": "^2.0.0",
@@ -2323,7 +2319,6 @@
     },
     "node_modules/@embroider/macros": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@embroider/shared-internals": "1.8.3",
@@ -2380,7 +2375,7 @@
     },
     "node_modules/@embroider/util": {
       "version": "1.9.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@embroider/macros": "^1.9.0",
@@ -2746,7 +2741,7 @@
     },
     "node_modules/@glimmer/vm-babel-plugins": {
       "version": "0.83.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "babel-plugin-debug-macros": "^0.3.4"
@@ -2818,7 +2813,7 @@
     },
     "node_modules/@jridgewell/source-map": {
       "version": "0.3.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
@@ -3259,6 +3254,7 @@
     },
     "node_modules/@types/acorn": {
       "version": "4.0.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "*"
@@ -3353,7 +3349,7 @@
     },
     "node_modules/@types/eslint": {
       "version": "8.4.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "*",
@@ -3362,7 +3358,7 @@
     },
     "node_modules/@types/eslint-scope": {
       "version": "3.7.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/eslint": "*",
@@ -3371,6 +3367,7 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.0",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/express": {
@@ -3424,7 +3421,7 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/mime": {
@@ -3491,7 +3488,7 @@
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.11.1",
@@ -3500,17 +3497,17 @@
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-code-frame": {
@@ -3551,7 +3548,7 @@
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.11.1",
@@ -3561,12 +3558,12 @@
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
@@ -3577,7 +3574,7 @@
     },
     "node_modules/@webassemblyjs/ieee754": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
@@ -3585,7 +3582,7 @@
     },
     "node_modules/@webassemblyjs/leb128": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@xtuc/long": "4.2.2"
@@ -3593,12 +3590,12 @@
     },
     "node_modules/@webassemblyjs/utf8": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
@@ -3613,7 +3610,7 @@
     },
     "node_modules/@webassemblyjs/wasm-edit/node_modules/@webassemblyjs/wast-printer": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
@@ -3622,7 +3619,7 @@
     },
     "node_modules/@webassemblyjs/wasm-gen": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
@@ -3634,7 +3631,7 @@
     },
     "node_modules/@webassemblyjs/wasm-opt": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
@@ -3645,7 +3642,7 @@
     },
     "node_modules/@webassemblyjs/wasm-parser": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
@@ -3729,12 +3726,12 @@
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/abab": {
@@ -3749,6 +3746,7 @@
     },
     "node_modules/abortcontroller-polyfill": {
       "version": "1.7.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/accepts": {
@@ -3765,7 +3763,7 @@
     },
     "node_modules/acorn": {
       "version": "8.8.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3776,6 +3774,7 @@
     },
     "node_modules/acorn-dynamic-import": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^5.0.0"
@@ -3783,6 +3782,7 @@
     },
     "node_modules/acorn-dynamic-import/node_modules/acorn": {
       "version": "5.7.4",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3813,7 +3813,7 @@
     },
     "node_modules/acorn-import-assertions": {
       "version": "1.8.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
@@ -3852,7 +3852,7 @@
     },
     "node_modules/ajv": {
       "version": "6.12.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -3875,7 +3875,7 @@
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "ajv": "^6.9.1"
@@ -3894,6 +3894,7 @@
     },
     "node_modules/amdefine": {
       "version": "1.0.1",
+      "devOptional": true,
       "license": "BSD-3-Clause OR MIT",
       "engines": {
         "node": ">=0.4.2"
@@ -3972,6 +3973,7 @@
     },
     "node_modules/ansi-to-html": {
       "version": "0.6.15",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^2.0.0"
@@ -4165,7 +4167,6 @@
     },
     "node_modules/assert-never": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/assert/node_modules/inherits": {
@@ -4191,7 +4192,7 @@
     },
     "node_modules/ast-types": {
       "version": "0.13.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -4511,7 +4512,7 @@
     },
     "node_modules/babel-loader": {
       "version": "8.2.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "find-cache-dir": "^3.3.1",
@@ -4529,7 +4530,7 @@
     },
     "node_modules/babel-loader/node_modules/schema-utils": {
       "version": "2.7.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.5",
@@ -4626,7 +4627,7 @@
     },
     "node_modules/babel-plugin-filter-imports": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.7.2",
@@ -4638,7 +4639,7 @@
     },
     "node_modules/babel-plugin-htmlbars-inline-precompile": {
       "version": "5.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
@@ -4707,7 +4708,7 @@
     },
     "node_modules/babel-plugin-syntax-dynamic-import": {
       "version": "6.18.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/babel-register": {
@@ -4864,11 +4865,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
-    },
     "node_modules/base/node_modules/define-property": {
       "version": "1.0.0",
       "dev": true,
@@ -4931,7 +4927,7 @@
     },
     "node_modules/big.js": {
       "version": "5.2.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -5751,6 +5747,7 @@
     },
     "node_modules/broccoli-concat": {
       "version": "4.2.5",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "broccoli-debug": "^0.6.5",
@@ -5771,6 +5768,7 @@
     },
     "node_modules/broccoli-concat/node_modules/broccoli-plugin": {
       "version": "4.0.7",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "broccoli-node-api": "^1.7.0",
@@ -5787,6 +5785,7 @@
     },
     "node_modules/broccoli-concat/node_modules/fast-sourcemap-concat": {
       "version": "2.1.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^2.0.0",
@@ -5804,6 +5803,7 @@
     },
     "node_modules/broccoli-concat/node_modules/fast-sourcemap-concat/node_modules/fs-extra": {
       "version": "5.0.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -5813,6 +5813,7 @@
     },
     "node_modules/broccoli-concat/node_modules/fs-extra": {
       "version": "8.1.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -5825,6 +5826,7 @@
     },
     "node_modules/broccoli-concat/node_modules/promise-map-series": {
       "version": "0.3.0",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "10.* || >= 12.*"
@@ -5832,6 +5834,7 @@
     },
     "node_modules/broccoli-concat/node_modules/rimraf": {
       "version": "3.0.2",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -5845,6 +5848,7 @@
     },
     "node_modules/broccoli-concat/node_modules/source-map": {
       "version": "0.4.4",
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "amdefine": ">=0.0.4"
@@ -6016,6 +6020,7 @@
     },
     "node_modules/broccoli-file-creator": {
       "version": "2.1.1",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "broccoli-plugin": "^1.1.0",
@@ -6081,7 +6086,7 @@
     },
     "node_modules/broccoli-funnel": {
       "version": "3.0.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "array-equal": "^1.0.0",
@@ -6103,7 +6108,7 @@
     },
     "node_modules/broccoli-funnel/node_modules/broccoli-plugin": {
       "version": "4.0.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "broccoli-node-api": "^1.7.0",
@@ -6120,7 +6125,7 @@
     },
     "node_modules/broccoli-funnel/node_modules/promise-map-series": {
       "version": "0.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "10.* || >= 12.*"
@@ -6128,7 +6133,7 @@
     },
     "node_modules/broccoli-funnel/node_modules/rimraf": {
       "version": "3.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -6164,6 +6169,7 @@
     },
     "node_modules/broccoli-merge-trees": {
       "version": "4.2.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "broccoli-plugin": "^4.0.2",
@@ -6175,6 +6181,7 @@
     },
     "node_modules/broccoli-merge-trees/node_modules/broccoli-plugin": {
       "version": "4.0.7",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "broccoli-node-api": "^1.7.0",
@@ -6191,6 +6198,7 @@
     },
     "node_modules/broccoli-merge-trees/node_modules/promise-map-series": {
       "version": "0.3.0",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "10.* || >= 12.*"
@@ -6198,6 +6206,7 @@
     },
     "node_modules/broccoli-merge-trees/node_modules/rimraf": {
       "version": "3.0.2",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -6225,10 +6234,12 @@
     },
     "node_modules/broccoli-node-api": {
       "version": "1.7.0",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/broccoli-node-info": {
       "version": "2.2.0",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "8.* || >= 10.*"
@@ -6236,6 +6247,7 @@
     },
     "node_modules/broccoli-output-wrapper": {
       "version": "3.2.5",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^8.1.0",
@@ -6248,6 +6260,7 @@
     },
     "node_modules/broccoli-output-wrapper/node_modules/fs-extra": {
       "version": "8.1.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -6260,7 +6273,7 @@
     },
     "node_modules/broccoli-persistent-filter": {
       "version": "3.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "async-disk-cache": "^2.0.0",
@@ -6281,7 +6294,7 @@
     },
     "node_modules/broccoli-persistent-filter/node_modules/async-disk-cache": {
       "version": "2.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
@@ -6298,7 +6311,7 @@
     },
     "node_modules/broccoli-persistent-filter/node_modules/broccoli-plugin": {
       "version": "4.0.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "broccoli-node-api": "^1.7.0",
@@ -6315,7 +6328,7 @@
     },
     "node_modules/broccoli-persistent-filter/node_modules/broccoli-plugin/node_modules/promise-map-series": {
       "version": "0.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "10.* || >= 12.*"
@@ -6323,7 +6336,7 @@
     },
     "node_modules/broccoli-persistent-filter/node_modules/editions": {
       "version": "2.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "errlop": "^2.0.0",
@@ -6338,7 +6351,7 @@
     },
     "node_modules/broccoli-persistent-filter/node_modules/istextorbinary": {
       "version": "2.6.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "binaryextensions": "^2.1.2",
@@ -6354,7 +6367,7 @@
     },
     "node_modules/broccoli-persistent-filter/node_modules/rimraf": {
       "version": "3.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -6368,7 +6381,7 @@
     },
     "node_modules/broccoli-persistent-filter/node_modules/semver": {
       "version": "6.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6386,6 +6399,7 @@
     },
     "node_modules/broccoli-rollup": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^9.6.0",
@@ -6406,10 +6420,12 @@
     },
     "node_modules/broccoli-rollup/node_modules/@types/node": {
       "version": "9.6.61",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/broccoli-rollup/node_modules/acorn": {
       "version": "5.7.4",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -6420,6 +6436,7 @@
     },
     "node_modules/broccoli-rollup/node_modules/fs-tree-diff": {
       "version": "0.5.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "heimdalljs-logger": "^0.1.7",
@@ -6430,6 +6447,7 @@
     },
     "node_modules/broccoli-rollup/node_modules/magic-string": {
       "version": "0.24.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sourcemap-codec": "^1.4.1"
@@ -6437,6 +6455,7 @@
     },
     "node_modules/broccoli-rollup/node_modules/matcher-collection": {
       "version": "1.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minimatch": "^3.0.2"
@@ -6444,6 +6463,7 @@
     },
     "node_modules/broccoli-rollup/node_modules/rollup": {
       "version": "0.57.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/acorn": "^4.0.3",
@@ -6464,6 +6484,7 @@
     },
     "node_modules/broccoli-rollup/node_modules/walk-sync": {
       "version": "0.3.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ensure-posix-path": "^1.0.0",
@@ -6480,7 +6501,7 @@
     },
     "node_modules/broccoli-source": {
       "version": "3.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "broccoli-node-api": "^1.6.0"
@@ -6511,6 +6532,7 @@
     },
     "node_modules/broccoli-stew": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "broccoli-debug": "^0.6.5",
@@ -6534,6 +6556,7 @@
     },
     "node_modules/broccoli-stew/node_modules/broccoli-funnel": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-equal": "^1.0.0",
@@ -6556,6 +6579,7 @@
     },
     "node_modules/broccoli-stew/node_modules/broccoli-funnel/node_modules/broccoli-plugin": {
       "version": "1.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "promise-map-series": "^0.2.1",
@@ -6566,6 +6590,7 @@
     },
     "node_modules/broccoli-stew/node_modules/broccoli-funnel/node_modules/debug": {
       "version": "2.6.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -6573,6 +6598,7 @@
     },
     "node_modules/broccoli-stew/node_modules/broccoli-funnel/node_modules/walk-sync": {
       "version": "0.3.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ensure-posix-path": "^1.0.0",
@@ -6581,6 +6607,7 @@
     },
     "node_modules/broccoli-stew/node_modules/broccoli-merge-trees": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "broccoli-plugin": "^1.3.0",
@@ -6592,6 +6619,7 @@
     },
     "node_modules/broccoli-stew/node_modules/broccoli-merge-trees/node_modules/broccoli-plugin": {
       "version": "1.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "promise-map-series": "^0.2.1",
@@ -6602,6 +6630,7 @@
     },
     "node_modules/broccoli-stew/node_modules/broccoli-persistent-filter": {
       "version": "2.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "async-disk-cache": "^1.2.1",
@@ -6625,6 +6654,7 @@
     },
     "node_modules/broccoli-stew/node_modules/broccoli-persistent-filter/node_modules/broccoli-plugin": {
       "version": "1.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "promise-map-series": "^0.2.1",
@@ -6635,6 +6665,7 @@
     },
     "node_modules/broccoli-stew/node_modules/broccoli-persistent-filter/node_modules/fs-tree-diff": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/symlink-or-copy": "^1.2.0",
@@ -6649,6 +6680,7 @@
     },
     "node_modules/broccoli-stew/node_modules/broccoli-plugin": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "promise-map-series": "^0.2.1",
@@ -6662,6 +6694,7 @@
     },
     "node_modules/broccoli-stew/node_modules/fs-extra": {
       "version": "8.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -6674,6 +6707,7 @@
     },
     "node_modules/broccoli-stew/node_modules/fs-tree-diff": {
       "version": "0.5.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "heimdalljs-logger": "^0.1.7",
@@ -6684,6 +6718,7 @@
     },
     "node_modules/broccoli-stew/node_modules/matcher-collection": {
       "version": "1.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minimatch": "^3.0.2"
@@ -6691,10 +6726,12 @@
     },
     "node_modules/broccoli-stew/node_modules/ms": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/broccoli-stew/node_modules/sync-disk-cache": {
       "version": "1.3.4",
+      "dev": true,
       "dependencies": {
         "debug": "^2.1.3",
         "heimdalljs": "^0.2.3",
@@ -6705,6 +6742,7 @@
     },
     "node_modules/broccoli-stew/node_modules/sync-disk-cache/node_modules/debug": {
       "version": "2.6.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -6712,6 +6750,7 @@
     },
     "node_modules/broccoli-stew/node_modules/walk-sync": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/minimatch": "^3.0.3",
@@ -6721,6 +6760,7 @@
     },
     "node_modules/broccoli-templater": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "broccoli-plugin": "^1.3.1",
@@ -6735,6 +6775,7 @@
     },
     "node_modules/broccoli-templater/node_modules/fs-tree-diff": {
       "version": "0.5.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "heimdalljs-logger": "^0.1.7",
@@ -6745,6 +6786,7 @@
     },
     "node_modules/broccoli-templater/node_modules/matcher-collection": {
       "version": "1.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minimatch": "^3.0.2"
@@ -6752,6 +6794,7 @@
     },
     "node_modules/broccoli-templater/node_modules/walk-sync": {
       "version": "0.3.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ensure-posix-path": "^1.0.0",
@@ -7117,7 +7160,7 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/buffer-xor": {
@@ -7294,6 +7337,7 @@
     },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.0.0",
@@ -7487,7 +7531,7 @@
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
@@ -7747,12 +7791,12 @@
     },
     "node_modules/commander": {
       "version": "2.20.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/common-tags": {
       "version": "1.8.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
@@ -7760,7 +7804,7 @@
     },
     "node_modules/commondir": {
       "version": "1.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/component-emitter": {
@@ -8271,6 +8315,7 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -8364,6 +8409,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -8376,6 +8422,7 @@
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8418,7 +8465,7 @@
     },
     "node_modules/css-loader": {
       "version": "5.2.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "icss-utils": "^5.1.0",
@@ -8458,7 +8505,7 @@
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -8534,6 +8581,7 @@
     },
     "node_modules/date-time": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "time-zone": "^1.0.0"
@@ -9063,7 +9111,7 @@
     },
     "node_modules/ember-auto-import": {
       "version": "2.4.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.7",
@@ -9103,7 +9151,7 @@
     },
     "node_modules/ember-auto-import/node_modules/broccoli-plugin": {
       "version": "4.0.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "broccoli-node-api": "^1.7.0",
@@ -9120,7 +9168,7 @@
     },
     "node_modules/ember-auto-import/node_modules/fs-extra": {
       "version": "10.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -9133,7 +9181,7 @@
     },
     "node_modules/ember-auto-import/node_modules/jsonfile": {
       "version": "6.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -9144,7 +9192,7 @@
     },
     "node_modules/ember-auto-import/node_modules/promise-map-series": {
       "version": "0.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "10.* || >= 12.*"
@@ -9152,7 +9200,7 @@
     },
     "node_modules/ember-auto-import/node_modules/resolve-package-path": {
       "version": "4.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-root": "^0.1.1"
@@ -9163,7 +9211,7 @@
     },
     "node_modules/ember-auto-import/node_modules/rimraf": {
       "version": "3.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -9177,7 +9225,7 @@
     },
     "node_modules/ember-auto-import/node_modules/universalify": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -9185,7 +9233,7 @@
     },
     "node_modules/ember-auto-import/node_modules/walk-sync": {
       "version": "3.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/minimatch": "^3.0.4",
@@ -9548,7 +9596,7 @@
     },
     "node_modules/ember-cli-get-component-path-option": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/ember-cli-htmlbars": {
@@ -9669,7 +9717,7 @@
     },
     "node_modules/ember-cli-normalize-entity-name": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "silent-error": "^1.0.0"
@@ -9677,7 +9725,7 @@
     },
     "node_modules/ember-cli-path-utils": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/ember-cli-preprocess-registry": {
@@ -9776,7 +9824,7 @@
     },
     "node_modules/ember-cli-string-utils": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/ember-cli-terser": {
@@ -10116,7 +10164,7 @@
     },
     "node_modules/ember-compatibility-helpers": {
       "version": "1.2.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "babel-plugin-debug-macros": "^0.2.0",
@@ -10131,7 +10179,7 @@
     },
     "node_modules/ember-compatibility-helpers/node_modules/babel-plugin-debug-macros": {
       "version": "0.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^5.3.0"
@@ -10145,22 +10193,21 @@
     },
     "node_modules/ember-compatibility-helpers/node_modules/semver": {
       "version": "5.7.1",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/ember-cookies": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.1.1.tgz",
+      "integrity": "sha512-72GsE2ibwUeEMoLa8yggF+Y5+W/koVG9vU166pnM8HFTsZKLC6RSIfWnkkGmJva06yPKPgusmymAatF+5hjjjQ==",
       "dependencies": {
-        "ember-cli-babel": "^7.1.0",
-        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
+        "@embroider/addon-shim": "^1.7.1"
       },
       "engines": {
-        "node": "8.* || 10.* || >= 12.*"
+        "node": ">= 16.*"
       }
     },
     "node_modules/ember-data": {
@@ -10190,7 +10237,7 @@
     },
     "node_modules/ember-destroyable-polyfill": {
       "version": "2.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ember-cli-babel": "^7.22.1",
@@ -10217,39 +10264,9 @@
         "node": ">= 4"
       }
     },
-    "node_modules/ember-factory-for-polyfill": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
-      "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
-      "dependencies": {
-        "ember-cli-version-checker": "^2.1.0"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-factory-for-polyfill/node_modules/ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dependencies": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/ember-factory-for-polyfill/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/ember-fetch": {
       "version": "8.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abortcontroller-polyfill": "^1.7.3",
@@ -10273,6 +10290,7 @@
     },
     "node_modules/ember-fetch/node_modules/ember-cli-typescript": {
       "version": "4.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-to-html": "^0.6.15",
@@ -10288,38 +10306,6 @@
       },
       "engines": {
         "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-getowner-polyfill": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
-      "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
-      "dependencies": {
-        "ember-cli-version-checker": "^2.1.0",
-        "ember-factory-for-polyfill": "^1.3.1"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-getowner-polyfill/node_modules/ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dependencies": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/ember-getowner-polyfill/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/ember-inflector": {
@@ -11090,7 +11076,7 @@
     },
     "node_modules/ember-router-generator": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.4.5",
@@ -11102,93 +11088,29 @@
       }
     },
     "node_modules/ember-simple-auth": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-4.2.2.tgz",
-      "integrity": "sha512-D7W6OREUvf5OzeB0ePptSNBilccchRYukH4f7mkbL6WT+z6VEqRRAIaQuBZdFM6lrcSFGmzctINLZJwsIpI3wg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-6.0.0.tgz",
+      "integrity": "sha512-9SzSFApxZ74CD4UxIeTV+poIPeXcRLXWM60cMvC1SwTYjoc/p9DeQF0pVm6m1XV6uA3kPUzEsEn4/GeHc2YX1w==",
       "dependencies": {
-        "base-64": "^0.1.0",
-        "broccoli-file-creator": "^2.1.1",
-        "broccoli-funnel": "^1.2.0 || ^2.0.0",
-        "broccoli-merge-trees": "^4.0.0",
-        "ember-cli-babel": "^7.20.5",
+        "@ember/test-waiters": "^3",
+        "@embroider/addon-shim": "^1.0.0",
+        "@embroider/macros": "^1.0.0",
         "ember-cli-is-package-missing": "^1.0.0",
-        "ember-cookies": "^0.5.0",
+        "ember-cookies": "^1.0.0",
         "silent-error": "^1.0.0"
       },
-      "engines": {
-        "node": ">= 12"
-      },
       "peerDependencies": {
-        "ember-fetch": "^8.0.1"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/broccoli-funnel": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-      "dependencies": {
-        "array-equal": "^1.0.0",
-        "blank-object": "^1.0.1",
-        "broccoli-plugin": "^1.3.0",
-        "debug": "^2.2.0",
-        "fast-ordered-set": "^1.0.0",
-        "fs-tree-diff": "^0.5.3",
-        "heimdalljs": "^0.2.0",
-        "minimatch": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "path-posix": "^1.0.0",
-        "rimraf": "^2.4.3",
-        "symlink-or-copy": "^1.0.0",
-        "walk-sync": "^0.3.1"
+        "@ember/test-helpers": ">= 3 || > 2.7"
       },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/fs-tree-diff": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
-      "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
-      "dependencies": {
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/matcher-collection": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-      "dependencies": {
-        "minimatch": "^3.0.2"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/ember-simple-auth/node_modules/walk-sync": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
-      "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
-      "dependencies": {
-        "ensure-posix-path": "^1.0.0",
-        "matcher-collection": "^1.0.0"
+      "peerDependenciesMeta": {
+        "@ember/test-helpers": {
+          "optional": true
+        }
       }
     },
     "node_modules/ember-source": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
@@ -11237,7 +11159,7 @@
     },
     "node_modules/ember-source/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -11251,7 +11173,7 @@
     },
     "node_modules/ember-source/node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -11266,7 +11188,7 @@
     },
     "node_modules/ember-source/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -11277,12 +11199,12 @@
     },
     "node_modules/ember-source/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/ember-source/node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -11899,7 +11821,7 @@
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -11915,6 +11837,7 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -12005,6 +11928,7 @@
     },
     "node_modules/entities": {
       "version": "2.2.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -12012,7 +11936,7 @@
     },
     "node_modules/errlop": {
       "version": "2.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -12049,7 +11973,7 @@
     },
     "node_modules/es-abstract": {
       "version": "1.20.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -12117,12 +12041,12 @@
     },
     "node_modules/es-module-lexer": {
       "version": "0.9.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.4",
@@ -12433,7 +12357,7 @@
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -12445,7 +12369,7 @@
     },
     "node_modules/eslint-scope/node_modules/estraverse": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -12631,7 +12555,7 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -12654,7 +12578,7 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -12665,7 +12589,7 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -12698,7 +12622,7 @@
     },
     "node_modules/events": {
       "version": "3.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -12725,6 +12649,7 @@
     },
     "node_modules/execa": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.0",
@@ -12909,7 +12834,7 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -12987,7 +12912,7 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -13193,7 +13118,7 @@
     },
     "node_modules/find-cache-dir": {
       "version": "3.3.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "commondir": "^1.0.1",
@@ -13209,11 +13134,11 @@
     },
     "node_modules/find-index": {
       "version": "1.1.1",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -13228,7 +13153,6 @@
     },
     "node_modules/find-up/node_modules/path-exists": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13546,6 +13470,7 @@
     },
     "node_modules/fs-merger": {
       "version": "3.2.1",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "broccoli-node-api": "^1.7.0",
@@ -13557,6 +13482,7 @@
     },
     "node_modules/fs-merger/node_modules/fs-extra": {
       "version": "8.1.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -13569,6 +13495,7 @@
     },
     "node_modules/fs-tree-diff": {
       "version": "2.0.1",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/symlink-or-copy": "^1.2.0",
@@ -13666,7 +13593,7 @@
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -13688,7 +13615,7 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -13765,6 +13692,7 @@
     },
     "node_modules/get-stream": {
       "version": "5.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
@@ -13778,7 +13706,7 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -13905,7 +13833,7 @@
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/global-dirs": {
@@ -14043,7 +13971,7 @@
     },
     "node_modules/handlebars": {
       "version": "4.7.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
@@ -14092,7 +14020,7 @@
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -14100,7 +14028,7 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14128,7 +14056,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
@@ -14449,6 +14377,7 @@
     },
     "node_modules/human-signals": {
       "version": "1.1.1",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.12.0"
@@ -14467,7 +14396,7 @@
     },
     "node_modules/icss-utils": {
       "version": "5.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": "^10 || ^12 || >= 14"
@@ -14555,7 +14484,7 @@
     },
     "node_modules/inflection": {
       "version": "1.13.4",
-      "dev": true,
+      "devOptional": true,
       "engines": [
         "node >= 0.4.0"
       ],
@@ -14757,7 +14686,7 @@
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.0",
@@ -14841,7 +14770,7 @@
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.1"
@@ -14864,7 +14793,7 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -14884,7 +14813,7 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -14936,7 +14865,7 @@
     },
     "node_modules/is-date-object": {
       "version": "1.0.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -15080,7 +15009,7 @@
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15114,7 +15043,7 @@
     },
     "node_modules/is-number-object": {
       "version": "1.0.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -15176,6 +15105,7 @@
     },
     "node_modules/is-reference": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "*"
@@ -15183,7 +15113,7 @@
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -15207,7 +15137,7 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
@@ -15227,6 +15157,7 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15237,7 +15168,7 @@
     },
     "node_modules/is-string": {
       "version": "1.0.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -15251,7 +15182,7 @@
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
@@ -15289,7 +15220,7 @@
     },
     "node_modules/is-weakref": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
@@ -15328,7 +15259,7 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/isbinaryfile": {
@@ -15344,6 +15275,7 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -15390,7 +15322,7 @@
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -15491,12 +15423,12 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify": {
@@ -15875,7 +15807,7 @@
     },
     "node_modules/line-column": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "isarray": "^1.0.0",
@@ -15884,7 +15816,7 @@
     },
     "node_modules/line-column/node_modules/isobject": {
       "version": "2.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "isarray": "1.0.0"
@@ -15936,7 +15868,7 @@
     },
     "node_modules/loader-runner": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
@@ -15944,7 +15876,7 @@
     },
     "node_modules/loader-utils": {
       "version": "2.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "big.js": "^5.2.2",
@@ -15957,7 +15889,7 @@
     },
     "node_modules/loader-utils/node_modules/json5": {
       "version": "2.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -15973,11 +15905,11 @@
     },
     "node_modules/locate-character": {
       "version": "2.0.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -16043,6 +15975,7 @@
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/lodash.assign": {
@@ -16099,6 +16032,7 @@
     },
     "node_modules/lodash.foreach": {
       "version": "4.5.0",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/lodash.isarguments": {
@@ -16128,14 +16062,17 @@
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/lodash.omit": {
       "version": "4.5.0",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/lodash.restparam": {
@@ -16145,6 +16082,7 @@
     },
     "node_modules/lodash.template": {
       "version": "4.5.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "lodash._reinterpolate": "^3.0.0",
@@ -16153,6 +16091,7 @@
     },
     "node_modules/lodash.templatesettings": {
       "version": "4.2.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "lodash._reinterpolate": "^3.0.0"
@@ -16165,6 +16104,7 @@
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/lodash.uniqby": {
@@ -16238,7 +16178,7 @@
     },
     "node_modules/magic-string": {
       "version": "0.25.9",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
@@ -16246,7 +16186,7 @@
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^6.0.0"
@@ -16260,7 +16200,7 @@
     },
     "node_modules/make-dir/node_modules/semver": {
       "version": "6.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -16414,6 +16354,7 @@
     },
     "node_modules/memory-streams": {
       "version": "0.1.3",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": "~1.0.2"
@@ -16421,10 +16362,12 @@
     },
     "node_modules/memory-streams/node_modules/isarray": {
       "version": "0.0.1",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/memory-streams/node_modules/readable-stream": {
       "version": "1.0.34",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -16447,6 +16390,7 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/merge-trees": {
@@ -16564,7 +16508,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -16572,7 +16516,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -16583,6 +16527,7 @@
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -16598,7 +16543,7 @@
     },
     "node_modules/mini-css-extract-plugin": {
       "version": "2.6.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "schema-utils": "^4.0.0"
@@ -16616,7 +16561,7 @@
     },
     "node_modules/mini-css-extract-plugin/node_modules/ajv": {
       "version": "8.11.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -16631,7 +16576,7 @@
     },
     "node_modules/mini-css-extract-plugin/node_modules/ajv-formats": {
       "version": "2.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -16647,7 +16592,7 @@
     },
     "node_modules/mini-css-extract-plugin/node_modules/ajv-keywords": {
       "version": "5.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
@@ -16658,12 +16603,12 @@
     },
     "node_modules/mini-css-extract-plugin/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
@@ -16865,7 +16810,7 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -16953,7 +16898,7 @@
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/netmask": {
@@ -17027,6 +16972,7 @@
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -17045,14 +16991,17 @@
     },
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -17109,6 +17058,7 @@
     },
     "node_modules/node-modules-path": {
       "version": "1.0.2",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/node-notifier": {
@@ -17295,6 +17245,7 @@
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
@@ -17351,7 +17302,7 @@
     },
     "node_modules/object-inspect": {
       "version": "1.12.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -17430,6 +17381,7 @@
     },
     "node_modules/onetime": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -17599,7 +17551,7 @@
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -17613,7 +17565,6 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -17627,7 +17578,6 @@
     },
     "node_modules/p-locate/node_modules/p-limit": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -17652,7 +17602,7 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -17766,6 +17716,7 @@
     },
     "node_modules/parse-ms": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17790,7 +17741,7 @@
     },
     "node_modules/parse-static-imports": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/parse-url": {
@@ -17804,7 +17755,7 @@
     },
     "node_modules/parse5": {
       "version": "6.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/parseurl": {
@@ -17850,6 +17801,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -17966,7 +17918,7 @@
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
@@ -17977,7 +17929,7 @@
     },
     "node_modules/pkg-dir/node_modules/find-up": {
       "version": "4.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -17989,7 +17941,7 @@
     },
     "node_modules/pkg-dir/node_modules/locate-path": {
       "version": "5.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -18000,7 +17952,7 @@
     },
     "node_modules/pkg-dir/node_modules/p-locate": {
       "version": "4.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -18011,7 +17963,7 @@
     },
     "node_modules/pkg-dir/node_modules/path-exists": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -18106,7 +18058,7 @@
     },
     "node_modules/postcss": {
       "version": "8.4.17",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -18129,7 +18081,7 @@
     },
     "node_modules/postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": "^10 || ^12 || >= 14"
@@ -18140,7 +18092,7 @@
     },
     "node_modules/postcss-modules-local-by-default": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "icss-utils": "^5.0.0",
@@ -18156,7 +18108,7 @@
     },
     "node_modules/postcss-modules-scope": {
       "version": "3.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "postcss-selector-parser": "^6.0.4"
@@ -18170,7 +18122,7 @@
     },
     "node_modules/postcss-modules-values": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "icss-utils": "^5.0.0"
@@ -18184,7 +18136,7 @@
     },
     "node_modules/postcss-selector-parser": {
       "version": "6.0.10",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -18196,7 +18148,7 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -18241,6 +18193,7 @@
     },
     "node_modules/pretty-ms": {
       "version": "3.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parse-ms": "^1.0.0"
@@ -18259,7 +18212,7 @@
     },
     "node_modules/private": {
       "version": "0.1.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -18434,6 +18387,7 @@
     },
     "node_modules/pump": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -18461,7 +18415,7 @@
     },
     "node_modules/punycode": {
       "version": "2.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -18595,7 +18549,7 @@
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
@@ -18708,7 +18662,7 @@
     },
     "node_modules/recast": {
       "version": "0.18.10",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ast-types": "0.13.3",
@@ -18814,7 +18768,7 @@
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -19751,7 +19705,7 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -19759,6 +19713,7 @@
     },
     "node_modules/require-relative": {
       "version": "0.8.7",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/requireindex": {
@@ -20057,6 +20012,7 @@
     },
     "node_modules/rollup-pluginutils": {
       "version": "2.8.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "estree-walker": "^0.6.1"
@@ -20064,6 +20020,7 @@
     },
     "node_modules/rollup-pluginutils/node_modules/estree-walker": {
       "version": "0.6.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/rollup/node_modules/fsevents": {
@@ -20143,7 +20100,7 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -20174,7 +20131,7 @@
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -20298,7 +20255,7 @@
     },
     "node_modules/schema-utils": {
       "version": "3.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.8",
@@ -20379,7 +20336,7 @@
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
@@ -20442,6 +20399,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -20452,6 +20410,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20486,7 +20445,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
@@ -20499,6 +20458,7 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/silent-error": {
@@ -20784,7 +20744,7 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -20792,7 +20752,7 @@
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -20817,7 +20777,7 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.21",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -20826,14 +20786,17 @@
     },
     "node_modules/source-map-url": {
       "version": "0.3.0",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/sourcemap-validator": {
       "version": "1.1.1",
+      "devOptional": true,
       "dependencies": {
         "jsesc": "~0.3.x",
         "lodash.foreach": "^4.5.0",
@@ -20846,12 +20809,14 @@
     },
     "node_modules/sourcemap-validator/node_modules/jsesc": {
       "version": "0.3.0",
+      "devOptional": true,
       "bin": {
         "jsesc": "bin/jsesc"
       }
     },
     "node_modules/sourcemap-validator/node_modules/source-map": {
       "version": "0.1.43",
+      "devOptional": true,
       "dependencies": {
         "amdefine": ">=0.0.4"
       },
@@ -20954,6 +20919,7 @@
     },
     "node_modules/stagehand": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.0"
@@ -21019,6 +20985,7 @@
     },
     "node_modules/string_decoder": {
       "version": "0.10.31",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/string-template": {
@@ -21040,7 +21007,7 @@
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -21074,7 +21041,7 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -21087,7 +21054,7 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -21119,7 +21086,7 @@
     },
     "node_modules/strip-bom": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21135,6 +21102,7 @@
     },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -21153,7 +21121,7 @@
     },
     "node_modules/style-loader": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "loader-utils": "^2.0.0",
@@ -21238,7 +21206,7 @@
     },
     "node_modules/supports-color": {
       "version": "8.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -21271,7 +21239,7 @@
     },
     "node_modules/sync-disk-cache": {
       "version": "2.1.0",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "debug": "^4.1.1",
         "heimdalljs": "^0.2.6",
@@ -21285,7 +21253,7 @@
     },
     "node_modules/sync-disk-cache/node_modules/rimraf": {
       "version": "3.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -21378,7 +21346,7 @@
     },
     "node_modules/terser": {
       "version": "5.15.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
@@ -21395,7 +21363,7 @@
     },
     "node_modules/terser-webpack-plugin": {
       "version": "5.3.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.14",
@@ -21646,6 +21614,7 @@
     },
     "node_modules/time-zone": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -21982,7 +21951,7 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -22326,7 +22295,7 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -22515,6 +22484,7 @@
     },
     "node_modules/walk-sync": {
       "version": "2.2.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/minimatch": "^3.0.3",
@@ -22560,7 +22530,7 @@
     },
     "node_modules/watchpack": {
       "version": "2.4.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
@@ -22695,7 +22665,7 @@
     },
     "node_modules/webpack": {
       "version": "5.74.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -22750,12 +22720,12 @@
     },
     "node_modules/webpack/node_modules/@types/estree": {
       "version": "0.0.51",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/webpack/node_modules/enhanced-resolve": {
       "version": "5.10.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -22767,7 +22737,7 @@
     },
     "node_modules/webpack/node_modules/tapable": {
       "version": "2.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -22775,7 +22745,7 @@
     },
     "node_modules/webpack/node_modules/webpack-sources": {
       "version": "3.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
@@ -22812,6 +22782,7 @@
     },
     "node_modules/whatwg-fetch": {
       "version": "3.6.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
@@ -22845,7 +22816,7 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.0.1",
@@ -23006,7 +22977,7 @@
     },
     "node_modules/wordwrap": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/worker-farm": {
@@ -23231,7 +23202,6 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -23249,7 +23219,7 @@
         "@embroider/test-setup": "^1.7.1",
         "@glimmer/component": "^1.0.4",
         "@glimmer/tracking": "^1.0.4",
-        "@lblod/ember-acmidm-login": "^0.0.0",
+        "@lblod/ember-acmidm-login": "^2.0.0-beta.1",
         "babel-eslint": "^10.1.0",
         "broccoli-asset-rev": "^3.0.0",
         "ember-auto-import": "^2.4.1",
@@ -23269,6 +23239,7 @@
         "ember-page-title": "^7.0.0",
         "ember-qunit": "^5.1.5",
         "ember-resolver": "^8.0.3",
+        "ember-simple-auth": "^6.0.0",
         "ember-source": "~4.3.0",
         "ember-source-channel-url": "^3.0.0",
         "ember-template-lint": "^4.3.0",
@@ -23288,18 +23259,6 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
-      }
-    },
-    "test-app/node_modules/@lblod/ember-acmidm-login": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-acmidm-login/-/ember-acmidm-login-0.0.0.tgz",
-      "integrity": "sha512-PJo+VPkgSDQefqg2V2DHHEaaumenGqY2f3jtC97WEeS8VPWIfr/RdgZwZJRMCxQbPN4mcvBnh+B7u6s5L27m+g==",
-      "dev": true,
-      "dependencies": {
-        "@embroider/addon-shim": "^1.0.0"
-      },
-      "peerDependencies": {
-        "ember-simple-auth": "4.x"
       }
     }
   },
@@ -24422,7 +24381,7 @@
     },
     "@ember/edition-utils": {
       "version": "1.2.0",
-      "dev": true
+      "devOptional": true
     },
     "@ember/optional-features": {
       "version": "2.0.0",
@@ -24484,7 +24443,7 @@
     },
     "@ember/test-helpers": {
       "version": "2.8.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@ember/test-waiters": "^3.0.0",
         "@embroider/macros": "^1.6.0",
@@ -24498,7 +24457,7 @@
       "dependencies": {
         "broccoli-plugin": {
           "version": "4.0.7",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "broccoli-node-api": "^1.7.0",
             "broccoli-output-wrapper": "^3.2.5",
@@ -24511,7 +24470,7 @@
         },
         "ember-cli-htmlbars": {
           "version": "5.7.2",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "@ember/edition-utils": "^1.2.0",
             "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
@@ -24533,11 +24492,11 @@
         },
         "promise-map-series": {
           "version": "0.3.0",
-          "dev": true
+          "devOptional": true
         },
         "rimraf": {
           "version": "3.0.2",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -24546,7 +24505,6 @@
     },
     "@ember/test-waiters": {
       "version": "3.0.2",
-      "dev": true,
       "requires": {
         "calculate-cache-key-for-tree": "^2.0.0",
         "ember-cli-babel": "^7.26.6",
@@ -24699,7 +24657,6 @@
     },
     "@embroider/macros": {
       "version": "1.9.0",
-      "dev": true,
       "requires": {
         "@embroider/shared-internals": "1.8.3",
         "assert-never": "^1.2.1",
@@ -24742,7 +24699,7 @@
     },
     "@embroider/util": {
       "version": "1.9.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@embroider/macros": "^1.9.0",
         "broccoli-funnel": "^3.0.5",
@@ -25026,7 +24983,7 @@
     },
     "@glimmer/vm-babel-plugins": {
       "version": "0.83.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "babel-plugin-debug-macros": "^0.3.4"
       }
@@ -25078,7 +25035,7 @@
     },
     "@jridgewell/source-map": {
       "version": "0.3.2",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -25434,6 +25391,7 @@
     },
     "@types/acorn": {
       "version": "4.0.6",
+      "dev": true,
       "requires": {
         "@types/estree": "*"
       }
@@ -25507,7 +25465,7 @@
     },
     "@types/eslint": {
       "version": "8.4.6",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -25515,14 +25473,15 @@
     },
     "@types/eslint-scope": {
       "version": "3.7.4",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/eslint": "*",
         "@types/estree": "*"
       }
     },
     "@types/estree": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "devOptional": true
     },
     "@types/express": {
       "version": "4.17.14",
@@ -25572,7 +25531,7 @@
     },
     "@types/json-schema": {
       "version": "7.0.11",
-      "dev": true
+      "devOptional": true
     },
     "@types/mime": {
       "version": "3.0.1",
@@ -25630,7 +25589,7 @@
     },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@webassemblyjs/helper-numbers": "1.11.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -25638,15 +25597,15 @@
     },
     "@webassemblyjs/floating-point-hex-parser": {
       "version": "1.11.1",
-      "dev": true
+      "devOptional": true
     },
     "@webassemblyjs/helper-api-error": {
       "version": "1.11.1",
-      "dev": true
+      "devOptional": true
     },
     "@webassemblyjs/helper-buffer": {
       "version": "1.11.1",
-      "dev": true
+      "devOptional": true
     },
     "@webassemblyjs/helper-code-frame": {
       "version": "1.9.0",
@@ -25683,7 +25642,7 @@
     },
     "@webassemblyjs/helper-numbers": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@webassemblyjs/floating-point-hex-parser": "1.11.1",
         "@webassemblyjs/helper-api-error": "1.11.1",
@@ -25692,11 +25651,11 @@
     },
     "@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.11.1",
-      "dev": true
+      "devOptional": true
     },
     "@webassemblyjs/helper-wasm-section": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-buffer": "1.11.1",
@@ -25706,25 +25665,25 @@
     },
     "@webassemblyjs/ieee754": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/utf8": {
       "version": "1.11.1",
-      "dev": true
+      "devOptional": true
     },
     "@webassemblyjs/wasm-edit": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-buffer": "1.11.1",
@@ -25738,7 +25697,7 @@
       "dependencies": {
         "@webassemblyjs/wast-printer": {
           "version": "1.11.1",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "@webassemblyjs/ast": "1.11.1",
             "@xtuc/long": "4.2.2"
@@ -25748,7 +25707,7 @@
     },
     "@webassemblyjs/wasm-gen": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -25759,7 +25718,7 @@
     },
     "@webassemblyjs/wasm-opt": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-buffer": "1.11.1",
@@ -25769,7 +25728,7 @@
     },
     "@webassemblyjs/wasm-parser": {
       "version": "1.11.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-api-error": "1.11.1",
@@ -25844,11 +25803,11 @@
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
-      "dev": true
+      "devOptional": true
     },
     "@xtuc/long": {
       "version": "4.2.2",
-      "dev": true
+      "devOptional": true
     },
     "abab": {
       "version": "2.0.6",
@@ -25859,7 +25818,8 @@
       "dev": true
     },
     "abortcontroller-polyfill": {
-      "version": "1.7.3"
+      "version": "1.7.3",
+      "dev": true
     },
     "accepts": {
       "version": "1.3.8",
@@ -25871,16 +25831,18 @@
     },
     "acorn": {
       "version": "8.8.0",
-      "dev": true
+      "devOptional": true
     },
     "acorn-dynamic-import": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "acorn": "^5.0.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.7.4"
+          "version": "5.7.4",
+          "dev": true
         }
       }
     },
@@ -25900,7 +25862,7 @@
     },
     "acorn-import-assertions": {
       "version": "1.8.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {}
     },
     "acorn-walk": {
@@ -25924,7 +25886,7 @@
     },
     "ajv": {
       "version": "6.12.6",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -25939,7 +25901,7 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
+      "devOptional": true,
       "requires": {}
     },
     "amd-name-resolver": {
@@ -25950,7 +25912,8 @@
       }
     },
     "amdefine": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "devOptional": true
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -25994,6 +25957,7 @@
     },
     "ansi-to-html": {
       "version": "0.6.15",
+      "dev": true,
       "requires": {
         "entities": "^2.0.0"
       }
@@ -26143,8 +26107,7 @@
       }
     },
     "assert-never": {
-      "version": "1.2.1",
-      "dev": true
+      "version": "1.2.1"
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -26152,7 +26115,7 @@
     },
     "ast-types": {
       "version": "0.13.3",
-      "dev": true
+      "devOptional": true
     },
     "astral-regex": {
       "version": "2.0.0",
@@ -26391,7 +26354,7 @@
     },
     "babel-loader": {
       "version": "8.2.5",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "find-cache-dir": "^3.3.1",
         "loader-utils": "^2.0.0",
@@ -26401,7 +26364,7 @@
       "dependencies": {
         "schema-utils": {
           "version": "2.7.1",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "@types/json-schema": "^7.0.5",
             "ajv": "^6.12.4",
@@ -26467,7 +26430,7 @@
     },
     "babel-plugin-filter-imports": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/types": "^7.7.2",
         "lodash": "^4.17.15"
@@ -26475,7 +26438,7 @@
     },
     "babel-plugin-htmlbars-inline-precompile": {
       "version": "5.3.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
         "line-column": "^1.0.2",
@@ -26522,7 +26485,7 @@
     },
     "babel-plugin-syntax-dynamic-import": {
       "version": "6.18.0",
-      "dev": true
+      "devOptional": true
     },
     "babel-register": {
       "version": "6.26.0",
@@ -26663,11 +26626,6 @@
         }
       }
     },
-    "base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
-    },
     "base64-js": {
       "version": "1.5.1",
       "dev": true
@@ -26697,7 +26655,7 @@
     },
     "big.js": {
       "version": "5.2.2",
-      "dev": true
+      "devOptional": true
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -27432,6 +27390,7 @@
     },
     "broccoli-concat": {
       "version": "4.2.5",
+      "devOptional": true,
       "requires": {
         "broccoli-debug": "^0.6.5",
         "broccoli-kitchen-sink-helpers": "^0.3.1",
@@ -27448,6 +27407,7 @@
       "dependencies": {
         "broccoli-plugin": {
           "version": "4.0.7",
+          "devOptional": true,
           "requires": {
             "broccoli-node-api": "^1.7.0",
             "broccoli-output-wrapper": "^3.2.5",
@@ -27460,6 +27420,7 @@
         },
         "fast-sourcemap-concat": {
           "version": "2.1.0",
+          "devOptional": true,
           "requires": {
             "chalk": "^2.0.0",
             "fs-extra": "^5.0.0",
@@ -27473,6 +27434,7 @@
           "dependencies": {
             "fs-extra": {
               "version": "5.0.0",
+              "devOptional": true,
               "requires": {
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^4.0.0",
@@ -27483,6 +27445,7 @@
         },
         "fs-extra": {
           "version": "8.1.0",
+          "devOptional": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
@@ -27490,16 +27453,19 @@
           }
         },
         "promise-map-series": {
-          "version": "0.3.0"
+          "version": "0.3.0",
+          "devOptional": true
         },
         "rimraf": {
           "version": "3.0.2",
+          "devOptional": true,
           "requires": {
             "glob": "^7.1.3"
           }
         },
         "source-map": {
           "version": "0.4.4",
+          "devOptional": true,
           "requires": {
             "amdefine": ">=0.0.4"
           }
@@ -27653,6 +27619,7 @@
     },
     "broccoli-file-creator": {
       "version": "2.1.1",
+      "devOptional": true,
       "requires": {
         "broccoli-plugin": "^1.1.0",
         "mkdirp": "^0.5.1"
@@ -27707,7 +27674,7 @@
     },
     "broccoli-funnel": {
       "version": "3.0.8",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "array-equal": "^1.0.0",
         "broccoli-plugin": "^4.0.7",
@@ -27720,7 +27687,7 @@
       "dependencies": {
         "broccoli-plugin": {
           "version": "4.0.7",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "broccoli-node-api": "^1.7.0",
             "broccoli-output-wrapper": "^3.2.5",
@@ -27733,11 +27700,11 @@
         },
         "promise-map-series": {
           "version": "0.3.0",
-          "dev": true
+          "devOptional": true
         },
         "rimraf": {
           "version": "3.0.2",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -27769,6 +27736,7 @@
     },
     "broccoli-merge-trees": {
       "version": "4.2.0",
+      "devOptional": true,
       "requires": {
         "broccoli-plugin": "^4.0.2",
         "merge-trees": "^2.0.0"
@@ -27776,6 +27744,7 @@
       "dependencies": {
         "broccoli-plugin": {
           "version": "4.0.7",
+          "devOptional": true,
           "requires": {
             "broccoli-node-api": "^1.7.0",
             "broccoli-output-wrapper": "^3.2.5",
@@ -27787,10 +27756,12 @@
           }
         },
         "promise-map-series": {
-          "version": "0.3.0"
+          "version": "0.3.0",
+          "devOptional": true
         },
         "rimraf": {
           "version": "3.0.2",
+          "devOptional": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -27808,13 +27779,16 @@
       }
     },
     "broccoli-node-api": {
-      "version": "1.7.0"
+      "version": "1.7.0",
+      "devOptional": true
     },
     "broccoli-node-info": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "devOptional": true
     },
     "broccoli-output-wrapper": {
       "version": "3.2.5",
+      "devOptional": true,
       "requires": {
         "fs-extra": "^8.1.0",
         "heimdalljs-logger": "^0.1.10",
@@ -27823,6 +27797,7 @@
       "dependencies": {
         "fs-extra": {
           "version": "8.1.0",
+          "devOptional": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
@@ -27833,7 +27808,7 @@
     },
     "broccoli-persistent-filter": {
       "version": "3.1.3",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "async-disk-cache": "^2.0.0",
         "async-promise-queue": "^1.0.3",
@@ -27850,7 +27825,7 @@
       "dependencies": {
         "async-disk-cache": {
           "version": "2.1.0",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "debug": "^4.1.1",
             "heimdalljs": "^0.2.3",
@@ -27863,7 +27838,7 @@
         },
         "broccoli-plugin": {
           "version": "4.0.7",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "broccoli-node-api": "^1.7.0",
             "broccoli-output-wrapper": "^3.2.5",
@@ -27876,13 +27851,13 @@
           "dependencies": {
             "promise-map-series": {
               "version": "0.3.0",
-              "dev": true
+              "devOptional": true
             }
           }
         },
         "editions": {
           "version": "2.3.1",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "errlop": "^2.0.0",
             "semver": "^6.3.0"
@@ -27890,7 +27865,7 @@
         },
         "istextorbinary": {
           "version": "2.6.0",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "binaryextensions": "^2.1.2",
             "editions": "^2.2.0",
@@ -27899,14 +27874,14 @@
         },
         "rimraf": {
           "version": "3.0.2",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "glob": "^7.1.3"
           }
         },
         "semver": {
           "version": "6.3.0",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -27921,6 +27896,7 @@
     },
     "broccoli-rollup": {
       "version": "2.1.1",
+      "dev": true,
       "requires": {
         "@types/node": "^9.6.0",
         "amd-name-resolver": "^1.2.0",
@@ -27936,13 +27912,16 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "9.6.61"
+          "version": "9.6.61",
+          "dev": true
         },
         "acorn": {
-          "version": "5.7.4"
+          "version": "5.7.4",
+          "dev": true
         },
         "fs-tree-diff": {
           "version": "0.5.9",
+          "dev": true,
           "requires": {
             "heimdalljs-logger": "^0.1.7",
             "object-assign": "^4.1.0",
@@ -27952,18 +27931,21 @@
         },
         "magic-string": {
           "version": "0.24.1",
+          "dev": true,
           "requires": {
             "sourcemap-codec": "^1.4.1"
           }
         },
         "matcher-collection": {
           "version": "1.1.2",
+          "dev": true,
           "requires": {
             "minimatch": "^3.0.2"
           }
         },
         "rollup": {
           "version": "0.57.1",
+          "dev": true,
           "requires": {
             "@types/acorn": "^4.0.3",
             "acorn": "^5.5.3",
@@ -27980,6 +27962,7 @@
         },
         "walk-sync": {
           "version": "0.3.4",
+          "dev": true,
           "requires": {
             "ensure-posix-path": "^1.0.0",
             "matcher-collection": "^1.0.0"
@@ -27996,7 +27979,7 @@
     },
     "broccoli-source": {
       "version": "3.0.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "broccoli-node-api": "^1.6.0"
       }
@@ -28020,6 +28003,7 @@
     },
     "broccoli-stew": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "broccoli-debug": "^0.6.5",
         "broccoli-funnel": "^2.0.0",
@@ -28039,6 +28023,7 @@
       "dependencies": {
         "broccoli-funnel": {
           "version": "2.0.2",
+          "dev": true,
           "requires": {
             "array-equal": "^1.0.0",
             "blank-object": "^1.0.1",
@@ -28057,6 +28042,7 @@
           "dependencies": {
             "broccoli-plugin": {
               "version": "1.3.1",
+              "dev": true,
               "requires": {
                 "promise-map-series": "^0.2.1",
                 "quick-temp": "^0.1.3",
@@ -28066,12 +28052,14 @@
             },
             "debug": {
               "version": "2.6.9",
+              "dev": true,
               "requires": {
                 "ms": "2.0.0"
               }
             },
             "walk-sync": {
               "version": "0.3.4",
+              "dev": true,
               "requires": {
                 "ensure-posix-path": "^1.0.0",
                 "matcher-collection": "^1.0.0"
@@ -28081,6 +28069,7 @@
         },
         "broccoli-merge-trees": {
           "version": "3.0.2",
+          "dev": true,
           "requires": {
             "broccoli-plugin": "^1.3.0",
             "merge-trees": "^2.0.0"
@@ -28088,6 +28077,7 @@
           "dependencies": {
             "broccoli-plugin": {
               "version": "1.3.1",
+              "dev": true,
               "requires": {
                 "promise-map-series": "^0.2.1",
                 "quick-temp": "^0.1.3",
@@ -28099,6 +28089,7 @@
         },
         "broccoli-persistent-filter": {
           "version": "2.3.1",
+          "dev": true,
           "requires": {
             "async-disk-cache": "^1.2.1",
             "async-promise-queue": "^1.0.3",
@@ -28118,6 +28109,7 @@
           "dependencies": {
             "broccoli-plugin": {
               "version": "1.3.1",
+              "dev": true,
               "requires": {
                 "promise-map-series": "^0.2.1",
                 "quick-temp": "^0.1.3",
@@ -28127,6 +28119,7 @@
             },
             "fs-tree-diff": {
               "version": "2.0.1",
+              "dev": true,
               "requires": {
                 "@types/symlink-or-copy": "^1.2.0",
                 "heimdalljs-logger": "^0.1.7",
@@ -28139,6 +28132,7 @@
         },
         "broccoli-plugin": {
           "version": "2.1.0",
+          "dev": true,
           "requires": {
             "promise-map-series": "^0.2.1",
             "quick-temp": "^0.1.3",
@@ -28148,6 +28142,7 @@
         },
         "fs-extra": {
           "version": "8.1.0",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
@@ -28156,6 +28151,7 @@
         },
         "fs-tree-diff": {
           "version": "0.5.9",
+          "dev": true,
           "requires": {
             "heimdalljs-logger": "^0.1.7",
             "object-assign": "^4.1.0",
@@ -28165,15 +28161,18 @@
         },
         "matcher-collection": {
           "version": "1.1.2",
+          "dev": true,
           "requires": {
             "minimatch": "^3.0.2"
           }
         },
         "ms": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "dev": true
         },
         "sync-disk-cache": {
           "version": "1.3.4",
+          "dev": true,
           "requires": {
             "debug": "^2.1.3",
             "heimdalljs": "^0.2.3",
@@ -28184,6 +28183,7 @@
           "dependencies": {
             "debug": {
               "version": "2.6.9",
+              "dev": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -28192,6 +28192,7 @@
         },
         "walk-sync": {
           "version": "1.1.4",
+          "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "ensure-posix-path": "^1.1.0",
@@ -28202,6 +28203,7 @@
     },
     "broccoli-templater": {
       "version": "2.0.2",
+      "dev": true,
       "requires": {
         "broccoli-plugin": "^1.3.1",
         "fs-tree-diff": "^0.5.9",
@@ -28212,6 +28214,7 @@
       "dependencies": {
         "fs-tree-diff": {
           "version": "0.5.9",
+          "dev": true,
           "requires": {
             "heimdalljs-logger": "^0.1.7",
             "object-assign": "^4.1.0",
@@ -28221,12 +28224,14 @@
         },
         "matcher-collection": {
           "version": "1.1.2",
+          "dev": true,
           "requires": {
             "minimatch": "^3.0.2"
           }
         },
         "walk-sync": {
           "version": "0.3.4",
+          "dev": true,
           "requires": {
             "ensure-posix-path": "^1.0.0",
             "matcher-collection": "^1.0.0"
@@ -28404,7 +28409,7 @@
     },
     "buffer-from": {
       "version": "1.1.2",
-      "dev": true
+      "devOptional": true
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -28535,6 +28540,7 @@
     },
     "caniuse-api": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "browserslist": "^4.0.0",
         "caniuse-lite": "^1.0.0",
@@ -28658,7 +28664,7 @@
     },
     "chrome-trace-event": {
       "version": "1.0.3",
-      "dev": true
+      "devOptional": true
     },
     "ci-info": {
       "version": "3.4.0",
@@ -28825,15 +28831,15 @@
     },
     "commander": {
       "version": "2.20.3",
-      "dev": true
+      "devOptional": true
     },
     "common-tags": {
       "version": "1.8.2",
-      "dev": true
+      "devOptional": true
     },
     "commondir": {
       "version": "1.0.1",
-      "dev": true
+      "devOptional": true
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -29198,7 +29204,8 @@
       }
     },
     "core-util-is": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "devOptional": true
     },
     "cors": {
       "version": "2.8.5",
@@ -29274,6 +29281,7 @@
     },
     "cross-spawn": {
       "version": "7.0.3",
+      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -29282,6 +29290,7 @@
       "dependencies": {
         "which": {
           "version": "2.0.2",
+          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -29311,7 +29320,7 @@
     },
     "css-loader": {
       "version": "5.2.7",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "icss-utils": "^5.1.0",
         "loader-utils": "^2.0.0",
@@ -29335,7 +29344,7 @@
     },
     "cssesc": {
       "version": "3.0.0",
-      "dev": true
+      "devOptional": true
     },
     "cssom": {
       "version": "0.4.4",
@@ -29383,6 +29392,7 @@
     },
     "date-time": {
       "version": "2.1.0",
+      "dev": true,
       "requires": {
         "time-zone": "^1.0.0"
       }
@@ -29751,7 +29761,7 @@
     },
     "ember-auto-import": {
       "version": "2.4.2",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/core": "^7.16.7",
         "@babel/plugin-proposal-class-properties": "^7.16.7",
@@ -29787,7 +29797,7 @@
       "dependencies": {
         "broccoli-plugin": {
           "version": "4.0.7",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "broccoli-node-api": "^1.7.0",
             "broccoli-output-wrapper": "^3.2.5",
@@ -29800,7 +29810,7 @@
         },
         "fs-extra": {
           "version": "10.1.0",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
@@ -29809,7 +29819,7 @@
         },
         "jsonfile": {
           "version": "6.1.0",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
@@ -29817,29 +29827,29 @@
         },
         "promise-map-series": {
           "version": "0.3.0",
-          "dev": true
+          "devOptional": true
         },
         "resolve-package-path": {
           "version": "4.0.3",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "path-root": "^0.1.1"
           }
         },
         "rimraf": {
           "version": "3.0.2",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "glob": "^7.1.3"
           }
         },
         "universalify": {
           "version": "2.0.0",
-          "dev": true
+          "devOptional": true
         },
         "walk-sync": {
           "version": "3.0.0",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "@types/minimatch": "^3.0.4",
             "ensure-posix-path": "^1.1.0",
@@ -30309,7 +30319,7 @@
     },
     "ember-cli-get-component-path-option": {
       "version": "1.0.0",
-      "dev": true
+      "devOptional": true
     },
     "ember-cli-htmlbars": {
       "version": "6.1.1",
@@ -30396,14 +30406,14 @@
     },
     "ember-cli-normalize-entity-name": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "silent-error": "^1.0.0"
       }
     },
     "ember-cli-path-utils": {
       "version": "1.0.0",
-      "dev": true
+      "devOptional": true
     },
     "ember-cli-preprocess-registry": {
       "version": "3.3.0",
@@ -30490,7 +30500,7 @@
     },
     "ember-cli-string-utils": {
       "version": "1.1.0",
-      "dev": true
+      "devOptional": true
     },
     "ember-cli-terser": {
       "version": "4.0.2",
@@ -30539,7 +30549,7 @@
     },
     "ember-compatibility-helpers": {
       "version": "1.2.6",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "babel-plugin-debug-macros": "^0.2.0",
         "ember-cli-version-checker": "^5.1.1",
@@ -30550,24 +30560,23 @@
       "dependencies": {
         "babel-plugin-debug-macros": {
           "version": "0.2.0",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "semver": "^5.3.0"
           }
         },
         "semver": {
           "version": "5.7.1",
-          "dev": true
+          "devOptional": true
         }
       }
     },
     "ember-cookies": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.1.1.tgz",
+      "integrity": "sha512-72GsE2ibwUeEMoLa8yggF+Y5+W/koVG9vU166pnM8HFTsZKLC6RSIfWnkkGmJva06yPKPgusmymAatF+5hjjjQ==",
       "requires": {
-        "ember-cli-babel": "^7.1.0",
-        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
+        "@embroider/addon-shim": "^1.7.1"
       }
     },
     "ember-data": {
@@ -30593,7 +30602,7 @@
     },
     "ember-destroyable-polyfill": {
       "version": "2.0.3",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "ember-cli-babel": "^7.22.1",
         "ember-cli-version-checker": "^5.1.1",
@@ -30608,32 +30617,9 @@
       "version": "2.0.1",
       "dev": true
     },
-    "ember-factory-for-polyfill": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
-      "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
-      "requires": {
-        "ember-cli-version-checker": "^2.1.0"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
-    },
     "ember-fetch": {
       "version": "8.1.2",
+      "dev": true,
       "requires": {
         "abortcontroller-polyfill": "^1.7.3",
         "broccoli-concat": "^4.2.5",
@@ -30653,6 +30639,7 @@
       "dependencies": {
         "ember-cli-typescript": {
           "version": "4.2.1",
+          "dev": true,
           "requires": {
             "ansi-to-html": "^0.6.15",
             "broccoli-stew": "^3.0.0",
@@ -30665,31 +30652,6 @@
             "stagehand": "^1.0.0",
             "walk-sync": "^2.2.0"
           }
-        }
-      }
-    },
-    "ember-getowner-polyfill": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
-      "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
-      "requires": {
-        "ember-cli-version-checker": "^2.1.0",
-        "ember-factory-for-polyfill": "^1.3.1"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
@@ -31250,7 +31212,7 @@
     },
     "ember-router-generator": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/parser": "^7.4.5",
         "@babel/traverse": "^7.4.5",
@@ -31258,86 +31220,21 @@
       }
     },
     "ember-simple-auth": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-4.2.2.tgz",
-      "integrity": "sha512-D7W6OREUvf5OzeB0ePptSNBilccchRYukH4f7mkbL6WT+z6VEqRRAIaQuBZdFM6lrcSFGmzctINLZJwsIpI3wg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-6.0.0.tgz",
+      "integrity": "sha512-9SzSFApxZ74CD4UxIeTV+poIPeXcRLXWM60cMvC1SwTYjoc/p9DeQF0pVm6m1XV6uA3kPUzEsEn4/GeHc2YX1w==",
       "requires": {
-        "base-64": "^0.1.0",
-        "broccoli-file-creator": "^2.1.1",
-        "broccoli-funnel": "^1.2.0 || ^2.0.0",
-        "broccoli-merge-trees": "^4.0.0",
-        "ember-cli-babel": "^7.20.5",
+        "@ember/test-waiters": "^3",
+        "@embroider/addon-shim": "^1.0.0",
+        "@embroider/macros": "^1.0.0",
         "ember-cli-is-package-missing": "^1.0.0",
-        "ember-cookies": "^0.5.0",
+        "ember-cookies": "^1.0.0",
         "silent-error": "^1.0.0"
-      },
-      "dependencies": {
-        "broccoli-funnel": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-          "requires": {
-            "array-equal": "^1.0.0",
-            "blank-object": "^1.0.1",
-            "broccoli-plugin": "^1.3.0",
-            "debug": "^2.2.0",
-            "fast-ordered-set": "^1.0.0",
-            "fs-tree-diff": "^0.5.3",
-            "heimdalljs": "^0.2.0",
-            "minimatch": "^3.0.0",
-            "mkdirp": "^0.5.0",
-            "path-posix": "^1.0.0",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0",
-            "walk-sync": "^0.3.1"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "fs-tree-diff": {
-          "version": "0.5.9",
-          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
-          "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
-          "requires": {
-            "heimdalljs-logger": "^0.1.7",
-            "object-assign": "^4.1.0",
-            "path-posix": "^1.0.0",
-            "symlink-or-copy": "^1.1.8"
-          }
-        },
-        "matcher-collection": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-          "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-          "requires": {
-            "minimatch": "^3.0.2"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-        },
-        "walk-sync": {
-          "version": "0.3.4",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
-          "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
-          "requires": {
-            "ensure-posix-path": "^1.0.0",
-            "matcher-collection": "^1.0.0"
-          }
-        }
       }
     },
     "ember-source": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/plugin-transform-block-scoping": "^7.16.0",
@@ -31368,14 +31265,14 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
           "version": "4.1.2",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -31383,18 +31280,18 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
           "version": "1.1.4",
-          "dev": true
+          "devOptional": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -31794,7 +31691,7 @@
     },
     "emojis-list": {
       "version": "3.0.0",
-      "dev": true
+      "devOptional": true
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -31802,6 +31699,7 @@
     },
     "end-of-stream": {
       "version": "1.4.4",
+      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -31857,11 +31755,12 @@
       "version": "1.1.1"
     },
     "entities": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "dev": true
     },
     "errlop": {
       "version": "2.2.0",
-      "dev": true
+      "devOptional": true
     },
     "errno": {
       "version": "0.1.8",
@@ -31886,7 +31785,7 @@
     },
     "es-abstract": {
       "version": "1.20.4",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -31946,11 +31845,11 @@
     },
     "es-module-lexer": {
       "version": "0.9.3",
-      "dev": true
+      "devOptional": true
     },
     "es-to-primitive": {
       "version": "1.2.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -32205,7 +32104,7 @@
     },
     "eslint-scope": {
       "version": "5.1.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -32213,7 +32112,7 @@
       "dependencies": {
         "estraverse": {
           "version": "4.3.0",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -32254,7 +32153,7 @@
     },
     "esprima": {
       "version": "4.0.1",
-      "dev": true
+      "devOptional": true
     },
     "esquery": {
       "version": "1.4.0",
@@ -32265,14 +32164,14 @@
     },
     "esrecurse": {
       "version": "4.3.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "estraverse": "^5.2.0"
       }
     },
     "estraverse": {
       "version": "5.3.0",
-      "dev": true
+      "devOptional": true
     },
     "estree-walker": {
       "version": "1.0.1",
@@ -32291,7 +32190,7 @@
     },
     "events": {
       "version": "3.3.0",
-      "dev": true
+      "devOptional": true
     },
     "events-to-array": {
       "version": "1.1.2",
@@ -32311,6 +32210,7 @@
     },
     "execa": {
       "version": "4.1.0",
+      "dev": true,
       "requires": {
         "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
@@ -32455,7 +32355,7 @@
     },
     "fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true
+      "devOptional": true
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -32509,7 +32409,7 @@
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
-      "dev": true
+      "devOptional": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -32658,7 +32558,7 @@
     },
     "find-cache-dir": {
       "version": "3.3.2",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "commondir": "^1.0.1",
         "make-dir": "^3.0.2",
@@ -32666,19 +32566,18 @@
       }
     },
     "find-index": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "devOptional": true
     },
     "find-up": {
       "version": "5.0.0",
-      "dev": true,
       "requires": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
       },
       "dependencies": {
         "path-exists": {
-          "version": "4.0.0",
-          "dev": true
+          "version": "4.0.0"
         }
       }
     },
@@ -32903,6 +32802,7 @@
     },
     "fs-merger": {
       "version": "3.2.1",
+      "devOptional": true,
       "requires": {
         "broccoli-node-api": "^1.7.0",
         "broccoli-node-info": "^2.1.0",
@@ -32913,6 +32813,7 @@
       "dependencies": {
         "fs-extra": {
           "version": "8.1.0",
+          "devOptional": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
@@ -32923,6 +32824,7 @@
     },
     "fs-tree-diff": {
       "version": "2.0.1",
+      "devOptional": true,
       "requires": {
         "@types/symlink-or-copy": "^1.2.0",
         "heimdalljs-logger": "^0.1.7",
@@ -33000,7 +32902,7 @@
     },
     "function.prototype.name": {
       "version": "1.1.5",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -33014,7 +32916,7 @@
     },
     "functions-have-names": {
       "version": "1.2.3",
-      "dev": true
+      "devOptional": true
     },
     "fuse.js": {
       "version": "6.6.2",
@@ -33061,13 +32963,14 @@
     },
     "get-stream": {
       "version": "5.2.0",
+      "dev": true,
       "requires": {
         "pump": "^3.0.0"
       }
     },
     "get-symbol-description": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -33157,7 +33060,7 @@
     },
     "glob-to-regexp": {
       "version": "0.4.1",
-      "dev": true
+      "devOptional": true
     },
     "global-dirs": {
       "version": "3.0.0",
@@ -33260,7 +33163,7 @@
     },
     "handlebars": {
       "version": "4.7.7",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
@@ -33290,11 +33193,11 @@
     },
     "has-bigints": {
       "version": "1.0.2",
-      "dev": true
+      "devOptional": true
     },
     "has-flag": {
       "version": "4.0.0",
-      "dev": true
+      "devOptional": true
     },
     "has-property-descriptors": {
       "version": "1.0.0",
@@ -33307,7 +33210,7 @@
     },
     "has-tostringtag": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -33549,7 +33452,8 @@
       }
     },
     "human-signals": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -33560,7 +33464,7 @@
     },
     "icss-utils": {
       "version": "5.1.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {}
     },
     "ieee754": {
@@ -33603,7 +33507,7 @@
     },
     "inflection": {
       "version": "1.13.4",
-      "dev": true
+      "devOptional": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -33740,7 +33644,7 @@
     },
     "internal-slot": {
       "version": "1.0.3",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
@@ -33799,7 +33703,7 @@
     },
     "is-bigint": {
       "version": "1.0.4",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "has-bigints": "^1.0.1"
       }
@@ -33814,7 +33718,7 @@
     },
     "is-boolean-object": {
       "version": "1.1.2",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -33826,7 +33730,7 @@
     },
     "is-callable": {
       "version": "1.2.7",
-      "dev": true
+      "devOptional": true
     },
     "is-ci": {
       "version": "3.0.1",
@@ -33858,7 +33762,7 @@
     },
     "is-date-object": {
       "version": "1.0.5",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -33938,7 +33842,7 @@
     },
     "is-negative-zero": {
       "version": "2.0.2",
-      "dev": true
+      "devOptional": true
     },
     "is-npm": {
       "version": "6.0.0",
@@ -33955,7 +33859,7 @@
     },
     "is-number-object": {
       "version": "1.0.7",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -33989,13 +33893,14 @@
     },
     "is-reference": {
       "version": "1.2.1",
+      "dev": true,
       "requires": {
         "@types/estree": "*"
       }
     },
     "is-regex": {
       "version": "1.1.4",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -34009,7 +33914,7 @@
     },
     "is-shared-array-buffer": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2"
       }
@@ -34024,18 +33929,19 @@
       }
     },
     "is-stream": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "dev": true
     },
     "is-string": {
       "version": "1.0.7",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
     },
     "is-symbol": {
       "version": "1.0.4",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -34057,7 +33963,7 @@
     },
     "is-weakref": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2"
       }
@@ -34081,14 +33987,15 @@
     },
     "isarray": {
       "version": "1.0.0",
-      "dev": true
+      "devOptional": true
     },
     "isbinaryfile": {
       "version": "4.0.10",
       "dev": true
     },
     "isexe": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "isobject": {
       "version": "3.0.1",
@@ -34120,7 +34027,7 @@
     },
     "jest-worker": {
       "version": "27.5.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -34187,11 +34094,11 @@
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
-      "dev": true
+      "devOptional": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "dev": true
+      "devOptional": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -34456,7 +34363,7 @@
     },
     "line-column": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "isarray": "^1.0.0",
         "isobject": "^2.0.0"
@@ -34464,7 +34371,7 @@
       "dependencies": {
         "isobject": {
           "version": "2.1.0",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "isarray": "1.0.0"
           }
@@ -34506,11 +34413,11 @@
     },
     "loader-runner": {
       "version": "4.3.0",
-      "dev": true
+      "devOptional": true
     },
     "loader-utils": {
       "version": "2.0.2",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -34519,7 +34426,7 @@
       "dependencies": {
         "json5": {
           "version": "2.2.1",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -34528,11 +34435,11 @@
       "dev": true
     },
     "locate-character": {
-      "version": "2.0.5"
+      "version": "2.0.5",
+      "dev": true
     },
     "locate-path": {
       "version": "6.0.0",
-      "dev": true,
       "requires": {
         "p-locate": "^5.0.0"
       }
@@ -34582,7 +34489,8 @@
       "dev": true
     },
     "lodash._reinterpolate": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "devOptional": true
     },
     "lodash.assign": {
       "version": "3.2.0",
@@ -34629,7 +34537,8 @@
       }
     },
     "lodash.foreach": {
-      "version": "4.5.0"
+      "version": "4.5.0",
+      "devOptional": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -34653,13 +34562,16 @@
       }
     },
     "lodash.memoize": {
-      "version": "4.1.2"
+      "version": "4.1.2",
+      "dev": true
     },
     "lodash.merge": {
-      "version": "4.6.2"
+      "version": "4.6.2",
+      "devOptional": true
     },
     "lodash.omit": {
-      "version": "4.5.0"
+      "version": "4.5.0",
+      "devOptional": true
     },
     "lodash.restparam": {
       "version": "3.6.1",
@@ -34667,6 +34579,7 @@
     },
     "lodash.template": {
       "version": "4.5.0",
+      "devOptional": true,
       "requires": {
         "lodash._reinterpolate": "^3.0.0",
         "lodash.templatesettings": "^4.0.0"
@@ -34674,6 +34587,7 @@
     },
     "lodash.templatesettings": {
       "version": "4.2.0",
+      "devOptional": true,
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
       }
@@ -34683,7 +34597,8 @@
       "dev": true
     },
     "lodash.uniq": {
-      "version": "4.5.0"
+      "version": "4.5.0",
+      "devOptional": true
     },
     "lodash.uniqby": {
       "version": "4.7.0",
@@ -34733,21 +34648,21 @@
     },
     "magic-string": {
       "version": "0.25.9",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "sourcemap-codec": "^1.4.8"
       }
     },
     "make-dir": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "semver": "^6.0.0"
       },
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -34863,15 +34778,18 @@
     },
     "memory-streams": {
       "version": "0.1.3",
+      "devOptional": true,
       "requires": {
         "readable-stream": "~1.0.2"
       },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1"
+          "version": "0.0.1",
+          "devOptional": true
         },
         "readable-stream": {
           "version": "1.0.34",
+          "devOptional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -34890,7 +34808,8 @@
       "dev": true
     },
     "merge-stream": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "devOptional": true
     },
     "merge-trees": {
       "version": "2.0.0",
@@ -34969,17 +34888,18 @@
     },
     "mime-db": {
       "version": "1.52.0",
-      "dev": true
+      "devOptional": true
     },
     "mime-types": {
       "version": "2.1.35",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "mime-db": "1.52.0"
       }
     },
     "mimic-fn": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "dev": true
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -34987,14 +34907,14 @@
     },
     "mini-css-extract-plugin": {
       "version": "2.6.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "schema-utils": "^4.0.0"
       },
       "dependencies": {
         "ajv": {
           "version": "8.11.0",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -35004,25 +34924,25 @@
         },
         "ajv-formats": {
           "version": "2.1.1",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "ajv": "^8.0.0"
           }
         },
         "ajv-keywords": {
           "version": "5.1.0",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "fast-deep-equal": "^3.1.3"
           }
         },
         "json-schema-traverse": {
           "version": "1.0.0",
-          "dev": true
+          "devOptional": true
         },
         "schema-utils": {
           "version": "4.0.0",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "@types/json-schema": "^7.0.9",
             "ajv": "^8.8.0",
@@ -35177,7 +35097,7 @@
     },
     "nanoid": {
       "version": "3.3.4",
-      "dev": true
+      "devOptional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -35235,7 +35155,7 @@
     },
     "neo-async": {
       "version": "2.6.2",
-      "dev": true
+      "devOptional": true
     },
     "netmask": {
       "version": "2.0.2",
@@ -35280,18 +35200,22 @@
     },
     "node-fetch": {
       "version": "2.6.7",
+      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       },
       "dependencies": {
         "tr46": {
-          "version": "0.0.3"
+          "version": "0.0.3",
+          "dev": true
         },
         "webidl-conversions": {
-          "version": "3.0.1"
+          "version": "3.0.1",
+          "dev": true
         },
         "whatwg-url": {
           "version": "5.0.0",
+          "dev": true,
           "requires": {
             "tr46": "~0.0.3",
             "webidl-conversions": "^3.0.0"
@@ -35346,7 +35270,8 @@
       }
     },
     "node-modules-path": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "node-notifier": {
       "version": "10.0.1",
@@ -35473,6 +35398,7 @@
     },
     "npm-run-path": {
       "version": "4.0.1",
+      "dev": true,
       "requires": {
         "path-key": "^3.0.0"
       }
@@ -35508,7 +35434,7 @@
     },
     "object-inspect": {
       "version": "1.12.2",
-      "dev": true
+      "devOptional": true
     },
     "object-keys": {
       "version": "1.1.1"
@@ -35555,6 +35481,7 @@
     },
     "onetime": {
       "version": "5.1.2",
+      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -35663,21 +35590,19 @@
     },
     "p-limit": {
       "version": "2.3.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "p-try": "^2.0.0"
       }
     },
     "p-locate": {
       "version": "5.0.0",
-      "dev": true,
       "requires": {
         "p-limit": "^3.0.2"
       },
       "dependencies": {
         "p-limit": {
           "version": "3.1.0",
-          "dev": true,
           "requires": {
             "yocto-queue": "^0.1.0"
           }
@@ -35693,7 +35618,7 @@
     },
     "p-try": {
       "version": "2.2.0",
-      "dev": true
+      "devOptional": true
     },
     "pac-proxy-agent": {
       "version": "5.0.0",
@@ -35779,7 +35704,8 @@
       }
     },
     "parse-ms": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "parse-passwd": {
       "version": "1.0.0",
@@ -35796,7 +35722,7 @@
     },
     "parse-static-imports": {
       "version": "1.1.0",
-      "dev": true
+      "devOptional": true
     },
     "parse-url": {
       "version": "8.1.0",
@@ -35809,7 +35735,7 @@
     },
     "parse5": {
       "version": "6.0.1",
-      "dev": true
+      "devOptional": true
     },
     "parseurl": {
       "version": "1.3.3",
@@ -35835,7 +35761,8 @@
       "version": "1.0.1"
     },
     "path-key": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.7"
@@ -35902,14 +35829,14 @@
     },
     "pkg-dir": {
       "version": "4.2.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "find-up": "^4.0.0"
       },
       "dependencies": {
         "find-up": {
           "version": "4.1.0",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
@@ -35917,21 +35844,21 @@
         },
         "locate-path": {
           "version": "5.0.0",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "p-locate": "^4.1.0"
           }
         },
         "p-locate": {
           "version": "4.1.0",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "p-limit": "^2.2.0"
           }
         },
         "path-exists": {
           "version": "4.0.0",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -35995,7 +35922,7 @@
     },
     "postcss": {
       "version": "8.4.17",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -36004,12 +35931,12 @@
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "icss-utils": "^5.0.0",
         "postcss-selector-parser": "^6.0.2",
@@ -36018,21 +35945,21 @@
     },
     "postcss-modules-scope": {
       "version": "3.0.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "postcss-selector-parser": "^6.0.4"
       }
     },
     "postcss-modules-values": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "icss-utils": "^5.0.0"
       }
     },
     "postcss-selector-parser": {
       "version": "6.0.10",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -36040,7 +35967,7 @@
     },
     "postcss-value-parser": {
       "version": "4.2.0",
-      "dev": true
+      "devOptional": true
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -36063,6 +35990,7 @@
     },
     "pretty-ms": {
       "version": "3.2.0",
+      "dev": true,
       "requires": {
         "parse-ms": "^1.0.0"
       }
@@ -36073,7 +36001,7 @@
     },
     "private": {
       "version": "0.1.8",
-      "dev": true
+      "devOptional": true
     },
     "process": {
       "version": "0.11.10",
@@ -36211,6 +36139,7 @@
     },
     "pump": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -36237,7 +36166,7 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "dev": true
+      "devOptional": true
     },
     "pupa": {
       "version": "3.1.0",
@@ -36312,7 +36241,7 @@
     },
     "randombytes": {
       "version": "2.1.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "safe-buffer": "^5.1.0"
       }
@@ -36400,7 +36329,7 @@
     },
     "recast": {
       "version": "0.18.10",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "ast-types": "0.13.3",
         "esprima": "~4.0.0",
@@ -36475,7 +36404,7 @@
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -37088,10 +37017,11 @@
     },
     "require-from-string": {
       "version": "2.0.2",
-      "dev": true
+      "devOptional": true
     },
     "require-relative": {
-      "version": "0.8.7"
+      "version": "0.8.7",
+      "dev": true
     },
     "requireindex": {
       "version": "1.2.0",
@@ -37300,12 +37230,14 @@
     },
     "rollup-pluginutils": {
       "version": "2.8.2",
+      "dev": true,
       "requires": {
         "estree-walker": "^0.6.1"
       },
       "dependencies": {
         "estree-walker": {
-          "version": "0.6.1"
+          "version": "0.6.1",
+          "dev": true
         }
       }
     },
@@ -37345,7 +37277,7 @@
     },
     "safe-buffer": {
       "version": "5.2.1",
-      "dev": true
+      "devOptional": true
     },
     "safe-json-parse": {
       "version": "1.0.1",
@@ -37360,7 +37292,7 @@
     },
     "safe-regex-test": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
@@ -37442,7 +37374,7 @@
     },
     "schema-utils": {
       "version": "3.1.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -37500,7 +37432,7 @@
     },
     "serialize-javascript": {
       "version": "6.0.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "randombytes": "^2.1.0"
       }
@@ -37547,12 +37479,14 @@
     },
     "shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
     },
     "shebang-regex": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "shell-quote": {
       "version": "1.7.3",
@@ -37575,7 +37509,7 @@
     },
     "side-channel": {
       "version": "1.0.4",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -37583,7 +37517,8 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.7"
+      "version": "3.0.7",
+      "dev": true
     },
     "silent-error": {
       "version": "1.1.1",
@@ -37800,11 +37735,11 @@
     },
     "source-map": {
       "version": "0.6.1",
-      "dev": true
+      "devOptional": true
     },
     "source-map-js": {
       "version": "1.0.2",
-      "dev": true
+      "devOptional": true
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -37825,20 +37760,23 @@
     },
     "source-map-support": {
       "version": "0.5.21",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
     },
     "source-map-url": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "devOptional": true
     },
     "sourcemap-codec": {
-      "version": "1.4.8"
+      "version": "1.4.8",
+      "devOptional": true
     },
     "sourcemap-validator": {
       "version": "1.1.1",
+      "devOptional": true,
       "requires": {
         "jsesc": "~0.3.x",
         "lodash.foreach": "^4.5.0",
@@ -37847,10 +37785,12 @@
       },
       "dependencies": {
         "jsesc": {
-          "version": "0.3.0"
+          "version": "0.3.0",
+          "devOptional": true
         },
         "source-map": {
           "version": "0.1.43",
+          "devOptional": true,
           "requires": {
             "amdefine": ">=0.0.4"
           }
@@ -37930,6 +37870,7 @@
     },
     "stagehand": {
       "version": "1.0.0",
+      "dev": true,
       "requires": {
         "debug": "^4.1.0"
       }
@@ -37978,7 +37919,8 @@
       "dev": true
     },
     "string_decoder": {
-      "version": "0.10.31"
+      "version": "0.10.31",
+      "devOptional": true
     },
     "string-template": {
       "version": "0.2.1",
@@ -37995,7 +37937,7 @@
     },
     "string.prototype.matchall": {
       "version": "4.0.7",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -38018,7 +37960,7 @@
     },
     "string.prototype.trimend": {
       "version": "1.0.5",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -38027,7 +37969,7 @@
     },
     "string.prototype.trimstart": {
       "version": "1.0.5",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -38049,14 +37991,15 @@
     },
     "strip-bom": {
       "version": "4.0.0",
-      "dev": true
+      "devOptional": true
     },
     "strip-eof": {
       "version": "1.0.0",
       "dev": true
     },
     "strip-final-newline": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "3.1.1",
@@ -38064,7 +38007,7 @@
     },
     "style-loader": {
       "version": "2.0.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "loader-utils": "^2.0.0",
         "schema-utils": "^3.0.0"
@@ -38118,7 +38061,7 @@
     },
     "supports-color": {
       "version": "8.1.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "has-flag": "^4.0.0"
       }
@@ -38135,7 +38078,7 @@
     },
     "sync-disk-cache": {
       "version": "2.1.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "debug": "^4.1.1",
         "heimdalljs": "^0.2.6",
@@ -38146,7 +38089,7 @@
       "dependencies": {
         "rimraf": {
           "version": "3.0.2",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -38212,7 +38155,7 @@
     },
     "terser": {
       "version": "5.15.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -38222,7 +38165,7 @@
     },
     "terser-webpack-plugin": {
       "version": "5.3.6",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.14",
         "jest-worker": "^27.4.5",
@@ -38239,7 +38182,7 @@
         "@embroider/test-setup": "^1.7.1",
         "@glimmer/component": "^1.0.4",
         "@glimmer/tracking": "^1.0.4",
-        "@lblod/ember-acmidm-login": "^0.0.0",
+        "@lblod/ember-acmidm-login": "^2.0.0-beta.1",
         "babel-eslint": "^10.1.0",
         "broccoli-asset-rev": "^3.0.0",
         "ember-auto-import": "^2.4.1",
@@ -38259,6 +38202,7 @@
         "ember-page-title": "^7.0.0",
         "ember-qunit": "^5.1.5",
         "ember-resolver": "^8.0.3",
+        "ember-simple-auth": "^6.0.0",
         "ember-source": "~4.3.0",
         "ember-source-channel-url": "^3.0.0",
         "ember-template-lint": "^4.3.0",
@@ -38275,17 +38219,6 @@
         "qunit": "^2.18.0",
         "qunit-dom": "^2.0.0",
         "webpack": "^5.70.0"
-      },
-      "dependencies": {
-        "@lblod/ember-acmidm-login": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/@lblod/ember-acmidm-login/-/ember-acmidm-login-0.0.0.tgz",
-          "integrity": "sha512-PJo+VPkgSDQefqg2V2DHHEaaumenGqY2f3jtC97WEeS8VPWIfr/RdgZwZJRMCxQbPN4mcvBnh+B7u6s5L27m+g==",
-          "dev": true,
-          "requires": {
-            "@embroider/addon-shim": "^1.0.0"
-          }
-        }
       }
     },
     "testem": {
@@ -38435,7 +38368,8 @@
       }
     },
     "time-zone": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "timers-browserify": {
       "version": "2.0.12",
@@ -38666,7 +38600,7 @@
     },
     "unbox-primitive": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-bigints": "^1.0.2",
@@ -38884,7 +38818,7 @@
     },
     "uri-js": {
       "version": "4.4.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -39028,6 +38962,7 @@
     },
     "walk-sync": {
       "version": "2.2.0",
+      "devOptional": true,
       "requires": {
         "@types/minimatch": "^3.0.3",
         "ensure-posix-path": "^1.1.0",
@@ -39062,7 +38997,7 @@
     },
     "watchpack": {
       "version": "2.4.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -39163,7 +39098,7 @@
     },
     "webpack": {
       "version": "5.74.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -39193,11 +39128,11 @@
       "dependencies": {
         "@types/estree": {
           "version": "0.0.51",
-          "dev": true
+          "devOptional": true
         },
         "enhanced-resolve": {
           "version": "5.10.0",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "graceful-fs": "^4.2.4",
             "tapable": "^2.2.0"
@@ -39205,11 +39140,11 @@
         },
         "tapable": {
           "version": "2.2.1",
-          "dev": true
+          "devOptional": true
         },
         "webpack-sources": {
           "version": "3.2.3",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -39242,7 +39177,8 @@
       }
     },
     "whatwg-fetch": {
-      "version": "3.6.2"
+      "version": "3.6.2",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
@@ -39266,7 +39202,7 @@
     },
     "which-boxed-primitive": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -39377,7 +39313,7 @@
     },
     "wordwrap": {
       "version": "1.0.0",
-      "dev": true
+      "devOptional": true
     },
     "worker-farm": {
       "version": "1.7.0",
@@ -39532,8 +39468,7 @@
       "dev": true
     },
     "yocto-queue": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,8 +28,5 @@
   ],
   "volta": {
     "node": "16.17.1"
-  },
-  "dependencies": {
-    "ember-simple-auth": "^4.2.2"
   }
 }

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -49,6 +49,7 @@
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.3",
+    "ember-simple-auth": "^6.0.0",
     "ember-source": "~4.3.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^4.3.0",


### PR DESCRIPTION
The APIs we use haven't changed between these versions, and this allows projects to use newer versions without overrides.