### PR TITLE
docs: add CallbackController to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ export default class CallbackRoute extends Route {
 }
 ```
 
-```
+```js
 // /app/controllers/callback.js
 import Controller from '@ember/controller';
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ import { inject as service } from '@ember/service';
 export default class CallbackRoute extends Route {
   @service session;
 
-  queryParams = ['code'];
   beforeModel() {
     // redirect to index if already authenticated
     this.session.prohibitAuthentication('index');
@@ -88,6 +87,15 @@ export default class CallbackRoute extends Route {
   async model(params) {
     this.session.authenticate('authenticator:acm-idm', params.code);
   }
+}
+```
+
+```
+// /app/controllers/callback.js
+import Controller from '@ember/controller';
+
+export default class CallbackController extends Controller {
+  queryParams = ['code'];
 }
 ```
 


### PR DESCRIPTION
To capture query params you have to define them in the controller of a route, this commits makes the controller explicit in the README.