### PR TITLE
Widen the `ember-simple-auth` peerDep range

### DIFF
--- a/.woodpecker/test-pr.yml
+++ b/.woodpecker/test-pr.yml
@@ -14,7 +14,7 @@ steps:
   test:
     image: danlynn/ember-cli:4.4.0
     commands:
-      - npm run test || exit 0
+      - npm run test
 when:
   event:
     - pull_request

--- a/ember-acmidm-login/package.json
+++ b/ember-acmidm-login/package.json
@@ -28,7 +28,7 @@
     "@embroider/addon-shim": "^1.0.0"
   },
   "peerDependencies": {
-    "ember-simple-auth": "4.x || 5.x || 6.x || 7.x"
+    "ember-simple-auth": ">= 4.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.17.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lblod/ember-acmidm-login",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lblod/ember-acmidm-login",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "workspaces": [
         "ember-acmidm-login",
@@ -21,7 +21,7 @@
     },
     "ember-acmidm-login": {
       "name": "@lblod/ember-acmidm-login",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@embroider/addon-shim": "^1.0.0"
@@ -46,7 +46,7 @@
         "rollup-plugin-copy": "^3.4.0"
       },
       "peerDependencies": {
-        "ember-simple-auth": "4.x || 5.x || 6.x || 7.x"
+        "ember-simple-auth": ">= 4.0.0"
       }
     },
     "ember-acmidm-login/node_modules/@babel/code-frame": {
@@ -11104,17 +11104,14 @@
       }
     },
     "node_modules/ember-simple-auth": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-7.1.3.tgz",
-      "integrity": "sha512-QMDc82evtQceEQFJ9C3RYptqAfGUY0Z5TenpVVsbmwdo5sC0mxlLolhkpj142JknvRLjTrtCWRtoML6V5pj1Dw==",
-      "license": "MIT",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-8.0.0.tgz",
+      "integrity": "sha512-ylFiMivRQgoBBOrTanml8AFiWivRy5LnHacmTMXdq8DEkWDqaswAE2xGzEejDnUbRKQXM9/T9Qym3dhnWmXUMw==",
       "dependencies": {
-        "@ember/test-waiters": "^3",
+        "@ember/test-waiters": "^3 || ^4",
         "@embroider/addon-shim": "^1.0.0",
         "@embroider/macros": "^1.0.0",
-        "ember-cli-is-package-missing": "^1.0.0",
-        "ember-cookies": "^1.3.0",
-        "silent-error": "^1.0.0"
+        "ember-cookies": "^1.3.0"
       },
       "peerDependencies": {
         "@ember/test-helpers": ">= 3 || > 2.7",
@@ -24251,7 +24248,7 @@
       }
     },
     "test-app": {
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -24263,7 +24260,7 @@
         "@embroider/test-setup": "^1.7.1",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
-        "@lblod/ember-acmidm-login": "^2.1.0",
+        "@lblod/ember-acmidm-login": "^2.2.0",
         "broccoli-asset-rev": "^3.0.0",
         "concurrently": "^8.2.2",
         "ember-auto-import": "^2.8.1",
@@ -24283,7 +24280,7 @@
         "ember-page-title": "^8.2.3",
         "ember-qunit": "^8.1.0",
         "ember-resolver": "^12.0.1",
-        "ember-simple-auth": "^7.0.0",
+        "ember-simple-auth": "^8.0.0",
         "ember-source": "~5.12.0",
         "ember-source-channel-url": "^3.0.0",
         "ember-template-lint": "^6.0.0",
@@ -34635,16 +34632,14 @@
       }
     },
     "ember-simple-auth": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-7.1.3.tgz",
-      "integrity": "sha512-QMDc82evtQceEQFJ9C3RYptqAfGUY0Z5TenpVVsbmwdo5sC0mxlLolhkpj142JknvRLjTrtCWRtoML6V5pj1Dw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-8.0.0.tgz",
+      "integrity": "sha512-ylFiMivRQgoBBOrTanml8AFiWivRy5LnHacmTMXdq8DEkWDqaswAE2xGzEejDnUbRKQXM9/T9Qym3dhnWmXUMw==",
       "requires": {
-        "@ember/test-waiters": "^3",
+        "@ember/test-waiters": "^3 || ^4",
         "@embroider/addon-shim": "^1.0.0",
         "@embroider/macros": "^1.0.0",
-        "ember-cli-is-package-missing": "^1.0.0",
-        "ember-cookies": "^1.3.0",
-        "silent-error": "^1.0.0"
+        "ember-cookies": "^1.3.0"
       }
     },
     "ember-source": {
@@ -42314,7 +42309,7 @@
         "@embroider/test-setup": "^1.7.1",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
-        "@lblod/ember-acmidm-login": "^2.1.0",
+        "@lblod/ember-acmidm-login": "^2.2.0",
         "broccoli-asset-rev": "^3.0.0",
         "concurrently": "^8.2.2",
         "ember-auto-import": "^2.8.1",
@@ -42334,7 +42329,7 @@
         "ember-page-title": "^8.2.3",
         "ember-qunit": "^8.1.0",
         "ember-resolver": "^12.0.1",
-        "ember-simple-auth": "^7.0.0",
+        "ember-simple-auth": "^8.0.0",
         "ember-source": "~5.12.0",
         "ember-source-channel-url": "^3.0.0",
         "ember-template-lint": "^6.0.0",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -55,7 +55,7 @@
     "ember-page-title": "^8.2.3",
     "ember-qunit": "^8.1.0",
     "ember-resolver": "^12.0.1",
-    "ember-simple-auth": "^7.0.0",
+    "ember-simple-auth": "^8.0.0",
     "ember-source": "~5.12.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^6.0.0",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -22,8 +22,7 @@
     "lint:js:fix": "eslint . --fix",
     "start": "ember serve",
     "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\"",
-    "test:ember": "ember test",
-    "test:watch": "ember test --server"
+    "test:ember": "ember test"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
This allows apps to use v8 (and newer versions) without having to use overrides or us having to PR and release a new version here.